### PR TITLE
svg import 타입 수정

### DIFF
--- a/src/assets/custom.d.ts
+++ b/src/assets/custom.d.ts
@@ -1,4 +1,4 @@
 declare module '*.svg' {
-  const content: any;
+  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
   export default content;
 }

--- a/src/assets/custom.d.ts
+++ b/src/assets/custom.d.ts
@@ -1,4 +1,4 @@
 declare module '*.svg' {
-  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
-  export default content;
+  const src: string;
+  export default src;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src/assets/custom.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src/assets/custom.d.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## ⛓ Related Issues
- close #10 

## 📋 작업 내용
- [x] costom.d.ts에서 지정한 svg의 타입을 any 말고 적절한 타입으로 수정해주기

## 📌 PR Point
- [웹팩](https://webpack.js.org/guides/typescript/#importing-other-assets)에서 권장한 방법은 맞지만,, no any 실천해보쟈!

## 🔬 레퍼런스
https://duncanleung.com/typescript-module-declearation-svg-img-assets/
http://daplus.net/typescript-typescript%EC%97%90%EC%84%9C-svg-%ED%8C%8C%EC%9D%BC%EC%9D%84-%EA%B0%80%EC%A0%B8%EC%98%AC-%EC%88%98-%EC%97%86%EC%8A%B5%EB%8B%88%EB%8B%A4/