### PR TITLE
FileUpload 컴포넌트의 StImgPreview 컴포넌트 border-radius 커스텀 가능하게 하기

### DIFF
--- a/src/presentation/components/common/FileUpload/index.tsx
+++ b/src/presentation/components/common/FileUpload/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { StImgPreview, StPhotoUpload, StUploadBtn } from './style';
+import { StImgPreview, StFileUpload, StUploadBtn } from './style';
 
-interface PhotoUploadProps {
+interface FileUploadProps {
   children: React.ReactElement | string;
   width: string;
   height: string;
@@ -9,7 +9,7 @@ interface PhotoUploadProps {
   setFile: (e: File) => void;
 }
 
-function PhotoUpload(props: PhotoUploadProps): React.ReactElement {
+function FileUpload(props: FileUploadProps): React.ReactElement {
   const { children, width, height, borderRadius, setFile } = props;
   const [newFile, setNewFile] = useState<File | null>(null);
   const [fileThumbnail, setFileThumbnail] = useState('');
@@ -40,7 +40,7 @@ function PhotoUpload(props: PhotoUploadProps): React.ReactElement {
   };
 
   return (
-    <StPhotoUpload>
+    <StFileUpload>
       <input
         hidden={true}
         ref={inputRef}
@@ -61,8 +61,8 @@ function PhotoUpload(props: PhotoUploadProps): React.ReactElement {
           />
         )}
       </StUploadBtn>
-    </StPhotoUpload>
+    </StFileUpload>
   );
 }
 
-export default PhotoUpload;
+export default FileUpload;

--- a/src/presentation/components/common/FileUpload/index.tsx
+++ b/src/presentation/components/common/FileUpload/index.tsx
@@ -5,12 +5,12 @@ interface FileUploadProps {
   children: React.ReactElement | string;
   width: string;
   height: string;
-  borderRadius: string;
+  borderRadius?: string;
   setFile: (e: File) => void;
 }
 
 function FileUpload(props: FileUploadProps): React.ReactElement {
-  const { children, width, height, borderRadius, setFile } = props;
+  const { children, width, height, borderRadius = '0px', setFile } = props;
   const [newFile, setNewFile] = useState<File | null>(null);
   const [fileThumbnail, setFileThumbnail] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/presentation/components/common/FileUpload/index.tsx
+++ b/src/presentation/components/common/FileUpload/index.tsx
@@ -5,11 +5,12 @@ interface PhotoUploadProps {
   children: React.ReactElement | string;
   width: string;
   height: string;
+  borderRadius: string;
   setFile: (e: File) => void;
 }
 
 function PhotoUpload(props: PhotoUploadProps): React.ReactElement {
-  const { children, width, height, setFile } = props;
+  const { children, width, height, borderRadius, setFile } = props;
   const [newFile, setNewFile] = useState<File | null>(null);
   const [fileThumbnail, setFileThumbnail] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -52,7 +53,12 @@ function PhotoUpload(props: PhotoUploadProps): React.ReactElement {
           children
         ) : (
           //업로드된 파일이 사진일 경우
-          <StImgPreview src={fileThumbnail} width={width} height={height} />
+          <StImgPreview
+            src={fileThumbnail}
+            width={width}
+            height={height}
+            borderRadius={borderRadius}
+          />
         )}
       </StUploadBtn>
     </StPhotoUpload>

--- a/src/presentation/components/common/FileUpload/style.ts
+++ b/src/presentation/components/common/FileUpload/style.ts
@@ -20,6 +20,6 @@ export const StUploadBtn = styled.button<{
   background-color: white;
 `;
 
-export const StPhotoUpload = styled.div`
+export const StFileUpload = styled.div`
   cursor: pointer;
 `;

--- a/src/presentation/components/common/FileUpload/style.ts
+++ b/src/presentation/components/common/FileUpload/style.ts
@@ -3,11 +3,12 @@ import styled from 'styled-components';
 export const StImgPreview = styled.img<{
   width: string;
   height: string;
+  borderRadius: string;
 }>`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
+  border-radius: ${(props) => props.borderRadius};
   object-fit: cover;
-  border-radius: 16px;
 `;
 
 export const StUploadBtn = styled.button<{


### PR DESCRIPTION
## ⛓ Related Issues
- close #33 

## 📋 작업 내용
- [x] FileUpload 컴포넌트의 StImgPreview 컴포넌트 border-radius 커스텀 가능하게 하기

## 📌 PR Point
이미지가 들어갈 컴포넌트의 border-radius가 뷰마다 달라서 커스텀 가능하도록 수정했습니다!
