### PR TITLE
팀원소개서 상세 페이지 팝업

### DIFF
--- a/src/presentation/pages/Team/Main/MemberPopup/index.tsx
+++ b/src/presentation/pages/Team/Main/MemberPopup/index.tsx
@@ -1,25 +1,20 @@
+import { TeamMembers } from '@api/types/team';
 import { StTeamMemberPopup } from './style';
 
-function TeamMemberPopup() {
+interface TeamMemberPopupProps {
+  members: TeamMembers[];
+}
+
+function TeamMemberPopup(props: TeamMemberPopupProps) {
+  const { members } = props;
   return (
     <StTeamMemberPopup>
-      {/* member 배열 map */}
-      <div>
-        <img src="https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg" />
-        <span>캐서린</span>
-      </div>
-      <div>
-        <img src="https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg" />
-        <span>웬디</span>
-      </div>
-      <div>
-        <img src="https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg" />
-        <span>콩콩이</span>
-      </div>
-      <div>
-        <img src="https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg" />
-        <span>크왕</span>
-      </div>
+      {members.map((member) => (
+        <div key={member.memberID}>
+          <img src={member.memberImage} />
+          <span>{member.memberName}</span>
+        </div>
+      ))}
     </StTeamMemberPopup>
   );
 }

--- a/src/presentation/pages/Team/Main/MemberPopup/index.tsx
+++ b/src/presentation/pages/Team/Main/MemberPopup/index.tsx
@@ -1,0 +1,27 @@
+import { StTeamMemberPopup } from './style';
+
+function TeamMemberPopup() {
+  return (
+    <StTeamMemberPopup>
+      {/* member 배열 map */}
+      <div>
+        <img src="https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg" />
+        <span>캐서린</span>
+      </div>
+      <div>
+        <img src="https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg" />
+        <span>웬디</span>
+      </div>
+      <div>
+        <img src="https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg" />
+        <span>콩콩이</span>
+      </div>
+      <div>
+        <img src="https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg" />
+        <span>크왕</span>
+      </div>
+    </StTeamMemberPopup>
+  );
+}
+
+export default TeamMemberPopup;

--- a/src/presentation/pages/Team/Main/MemberPopup/style.ts
+++ b/src/presentation/pages/Team/Main/MemberPopup/style.ts
@@ -7,7 +7,6 @@ export const StTeamMemberPopup = styled.div`
   left: 40px;
   z-index: 4;
   width: 168px;
-  /* visibility: hidden; */
   background: ${COLOR.WHITE};
   border-radius: 8.07692px;
   border: 0.8px solid ${COLOR.GRAY_3};

--- a/src/presentation/pages/Team/Main/MemberPopup/style.ts
+++ b/src/presentation/pages/Team/Main/MemberPopup/style.ts
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+import { COLOR } from '@styles/common/color';
+
+export const StTeamMemberPopup = styled.div`
+  position: absolute; /* relative */
+  z-index: 1;
+  width: 168px;
+  height: 207.17px;
+  /* visibility: hidden; */
+  background: ${COLOR.WHITE};
+  border-radius: 8.07692px;
+  border: 0.8px solid ${COLOR.GRAY_3};
+  box-shadow: 0px 10px 30px rgba(152, 151, 166, 0.15);
+  padding: 20px 15px;
+
+  &:after {
+    content: '';
+    position: absolute;
+    left: 79px;
+    top: -6px;
+    width: 10px;
+    height: 10px;
+    background: inherit;
+    transform: rotate(-45deg);
+    border-top: inherit;
+    border-right: inherit;
+    box-shadow: inherit;
+  }
+`;

--- a/src/presentation/pages/Team/Main/MemberPopup/style.ts
+++ b/src/presentation/pages/Team/Main/MemberPopup/style.ts
@@ -4,7 +4,8 @@ import { FONT_STYLES } from '@styles/common/font-style';
 
 export const StTeamMemberPopup = styled.div`
   position: absolute;
-  left: 40px;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 4;
   width: 168px;
   background: ${COLOR.WHITE};

--- a/src/presentation/pages/Team/Main/MemberPopup/style.ts
+++ b/src/presentation/pages/Team/Main/MemberPopup/style.ts
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import { COLOR } from '@styles/common/color';
+import { FONT_STYLES } from '@styles/common/font-style';
 
 export const StTeamMemberPopup = styled.div`
-  position: absolute; /* relative */
-  z-index: 1;
+  position: absolute;
+  left: 40px;
+  z-index: 4;
   width: 168px;
-  height: 207.17px;
   /* visibility: hidden; */
   background: ${COLOR.WHITE};
   border-radius: 8.07692px;
@@ -25,5 +26,28 @@ export const StTeamMemberPopup = styled.div`
     border-top: inherit;
     border-right: inherit;
     box-shadow: inherit;
+  }
+
+  div {
+    display: flex;
+    align-items: center;
+
+    span {
+      ${FONT_STYLES.M_13_BODY};
+      color: ${COLOR.GRAY_6};
+      line-height: 18.72px;
+    }
+  }
+
+  div + div {
+    margin-top: 13px;
+  }
+
+  img {
+    width: 32px;
+    height: 32px;
+    object-fit: cover;
+    margin-right: 15px;
+    border-radius: 77.0833px;
   }
 `;

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { StTeamMain, StTeamInfo, StCheckWrapper } from './style';
-import { icPerson, icPencil, icPlusMini, icCoralCheck, icGrayCheck } from '@assets/icons';
+import { icPerson, icPlusMini, icCoralCheck, icGrayCheck } from '@assets/icons';
 import IssueCardList from '@components/common/IssueCardList';
 import { useState, useEffect } from 'react';
 import { api } from '@api/index';
@@ -34,37 +34,19 @@ function TeamMain() {
     };
   }, []);
 
-  const openMemberPopup = () => {
-    setIsMemberPopupOpened(!isMemberPopupOpened);
-  };
-
-  const updateTeam = () => {
-    navigate(`/team/register`);
-  };
-
-  const createIssue = () => {
-    navigate(`/team/${teamID}/create`);
-  };
-
-  const findMyIssue = () => {
-    setIsChecked(!isChecked);
-  };
-
-  const handleIssueClick = (teamID: string, issueNumber: number) => {
-    navigate(`/team/${teamID}/${issueNumber}`);
-  };
-
   return (
     <StTeamMain>
       {isValidating && <div>로딩중</div>}
       {teamInfoData && (
         <StTeamInfo>
+          <div>
+            <button onClick={() => navigate(`/team/register`)}>수정</button>
+          </div>
           <img src={teamInfoData.teamImage ?? imgEmptyProfile} />
           <div>
             <h1>{teamInfoData.teamName}</h1>
-            <h2>{teamInfoData.teamDescription}</h2>
             <h3>
-              <img src={icPerson} onClick={openMemberPopup} />
+              <img src={icPerson} onClick={() => setIsMemberPopupOpened(!isMemberPopupOpened)} />
               <span>{teamInfoData.teamMembers.length}명</span>
               <span>|</span>
               {teamInfoData.teamMembers.map((member, index) => (
@@ -75,23 +57,28 @@ function TeamMain() {
               ))}
             </h3>
             {isMemberPopupOpened && <TeamMemberPopup members={teamInfoData.teamMembers} />}
+            <h2>{teamInfoData.teamDescription}</h2>
           </div>
-          <img src={icPencil} onClick={updateTeam} />
         </StTeamInfo>
       )}
-      <button onClick={createIssue}>
+      <button onClick={() => navigate(`/team/${teamID}/create`)}>
         <img src={icPlusMini} />
         이슈 추가
       </button>
       <StCheckWrapper>
-        <button onClick={findMyIssue}>
+        <button onClick={() => setIsChecked(!isChecked)}>
           <img src={isChecked ? icCoralCheck : icGrayCheck} />
         </button>
         나와 관련된 이슈만 보기
       </StCheckWrapper>
       {isValidating && <div>로딩중</div>}
       {issueListData && (
-        <IssueCardList issueListData={issueListData} onIssueClick={handleIssueClick} />
+        <IssueCardList
+          issueListData={issueListData}
+          onIssueClick={(teamID, issueNumber) => {
+            navigate(`/team/${teamID}/${issueNumber}`);
+          }}
+        />
       )}
     </StTeamMain>
   );

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 import { api } from '@api/index';
 import { TeamInfoData, TeamIssueCard } from '@api/types/team';
 import { imgEmptyProfile } from '@assets/images';
+import TeamMemberPopup from './MemberPopup';
 
 function TeamMain() {
   const [isChecked, setIsChecked] = useState(false);
@@ -68,6 +69,7 @@ function TeamMain() {
                 </span>
               ))}
             </h3>
+            <TeamMemberPopup />
           </div>
           <img src={icPencil} onClick={updateTeam} />
         </StTeamInfo>

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -9,6 +9,7 @@ import { imgEmptyProfile } from '@assets/images';
 import TeamMemberPopup from './MemberPopup';
 
 function TeamMain() {
+  const [isClicked, setIsClicked] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
   const [teamInfoData, setTeamInfoData] = useState<TeamInfoData | null>(null);
   const [issueListData, setIssueListData] = useState<TeamIssueCard[] | null>(null);
@@ -33,12 +34,16 @@ function TeamMain() {
     };
   }, []);
 
-  const createIssue = () => {
-    navigate(`/team/${teamID}/create`);
+  const showMembers = () => {
+    setIsClicked(!isClicked);
   };
 
   const updateTeam = () => {
     navigate(`/team/register`);
+  };
+
+  const createIssue = () => {
+    navigate(`/team/${teamID}/create`);
   };
 
   const findMyIssue = () => {
@@ -59,7 +64,7 @@ function TeamMain() {
             <h1>{teamInfoData.teamName}</h1>
             <h2>{teamInfoData.teamDescription}</h2>
             <h3>
-              <img src={icPerson} />
+              <img src={icPerson} onClick={showMembers} />
               <span>{teamInfoData.teamMembers.length}명</span>
               <span>|</span>
               {teamInfoData.teamMembers.map((member, index) => (
@@ -69,7 +74,7 @@ function TeamMain() {
                 </span>
               ))}
             </h3>
-            <TeamMemberPopup />
+            {isClicked && <TeamMemberPopup />}
           </div>
           <img src={icPencil} onClick={updateTeam} />
         </StTeamInfo>

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -9,7 +9,7 @@ import { imgEmptyProfile } from '@assets/images';
 import TeamMemberPopup from './MemberPopup';
 
 function TeamMain() {
-  const [isClicked, setIsClicked] = useState(false);
+  const [isMemberPopupOpened, setIsMemberPopupOpened] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
   const [teamInfoData, setTeamInfoData] = useState<TeamInfoData | null>(null);
   const [issueListData, setIssueListData] = useState<TeamIssueCard[] | null>(null);
@@ -34,8 +34,8 @@ function TeamMain() {
     };
   }, []);
 
-  const showMembers = () => {
-    setIsClicked(!isClicked);
+  const openMemberPopup = () => {
+    setIsMemberPopupOpened(!isMemberPopupOpened);
   };
 
   const updateTeam = () => {
@@ -64,7 +64,7 @@ function TeamMain() {
             <h1>{teamInfoData.teamName}</h1>
             <h2>{teamInfoData.teamDescription}</h2>
             <h3>
-              <img src={icPerson} onClick={showMembers} />
+              <img src={icPerson} onClick={openMemberPopup} />
               <span>{teamInfoData.teamMembers.length}명</span>
               <span>|</span>
               {teamInfoData.teamMembers.map((member, index) => (
@@ -74,7 +74,7 @@ function TeamMain() {
                 </span>
               ))}
             </h3>
-            {isClicked && <TeamMemberPopup />}
+            {isMemberPopupOpened && <TeamMemberPopup members={teamInfoData.teamMembers} />}
           </div>
           <img src={icPencil} onClick={updateTeam} />
         </StTeamInfo>

--- a/src/presentation/pages/Team/Main/style.ts
+++ b/src/presentation/pages/Team/Main/style.ts
@@ -14,7 +14,7 @@ export const StTeamMain = styled.div`
     ${CORAL_MAIN_BUTTON}
     ${FULL_WIDTH_BUTTON}
     ${FONT_STYLES.M_16_TITLE};
-    margin-top: 49px;
+    margin-top: 31.17px;
     margin-bottom: 27px;
 
     & > img {
@@ -57,9 +57,11 @@ export const StTeamInfo = styled.div`
       color: ${COLOR.GRAY_5};
       display: flex;
       align-items: center;
+      margin-bottom: 16.83px;
 
       img {
         margin-right: 6px;
+        cursor: pointer;
       }
 
       span:first-child,

--- a/src/presentation/pages/Team/Main/style.ts
+++ b/src/presentation/pages/Team/Main/style.ts
@@ -14,8 +14,8 @@ export const StTeamMain = styled.div`
     ${CORAL_MAIN_BUTTON}
     ${FULL_WIDTH_BUTTON}
     ${FONT_STYLES.M_16_TITLE};
-    margin-top: 31.17px;
-    margin-bottom: 27px;
+    margin-top: 36px;
+    margin-bottom: 35px;
 
     & > img {
       margin-right: 8px;
@@ -25,30 +25,47 @@ export const StTeamMain = styled.div`
 
 export const StTeamInfo = styled.div`
   display: flex;
-  margin-top: 43px;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 7px;
 
-  & > img:first-child {
+  & > div:first-child {
+    display: flex;
+    justify-content: end;
+    padding-top: 13px;
+    padding-bottom: 15px;
+    padding-right: 4px;
+    width: 100%;
+
+    button {
+      background-color: transparent;
+      color: ${COLOR.CORAL_MAIN};
+      ${FONT_STYLES.M_15_TITLE};
+    }
+  }
+
+  & > img:nth-of-type(1) {
     width: 82px;
     height: 82px;
     object-fit: cover;
-    margin-right: 18px;
-    margin-bottom: 1px;
+    margin-bottom: 18px;
     border-radius: 30px;
   }
 
-  div {
+  div:nth-of-type(2) {
     flex: 1;
+    text-align: center;
 
     h1 {
-      ${FONT_STYLES.B_24_TITLE};
-      margin-top: 5px;
-      margin-bottom: 10px;
-      color: ${COLOR.BLACK};
+      margin-bottom: 8px;
+      color: ${COLOR.GRAY_8};
+      font-weight: 600;
+      font-size: 20px;
+      letter-spacing: -0.015em;
     }
 
     h2 {
-      ${FONT_STYLES.R_14_TITLE};
-      margin-bottom: 15px;
+      ${FONT_STYLES.R_15_TITLE};
       color: ${COLOR.GRAY_7};
     }
 
@@ -57,10 +74,11 @@ export const StTeamInfo = styled.div`
       color: ${COLOR.GRAY_5};
       display: flex;
       align-items: center;
-      margin-bottom: 16.83px;
+      justify-content: center;
+      margin-bottom: 18px;
 
       img {
-        margin-right: 6px;
+        margin-right: 4px;
         cursor: pointer;
       }
 
@@ -82,12 +100,14 @@ export const StTeamInfo = styled.div`
 export const StCheckWrapper = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
+  color: ${COLOR.GRAY_7};
+  font-weight: 600;
 
   button {
     background: transparent;
     width: 24px;
     height: 24px;
-    margin-right: 5px;
+    margin-right: 8px;
   }
 `;


### PR DESCRIPTION
## ⛓ Related Issues
- close #67 

## 📋 작업 내용
- [x] 팝업 컴포넌트 구조화 및 스타일링
- [x] 사람 아이콘 클릭 시 팝업 나타나도록 구현
- [x] mock data 사용

## 📌 PR Point
- MemberPopup 폴더를 하나 생성하고 작업했습니다.
- 상세 페이지 작업 시 만들었던 `teamInfoData.teamMembers`를 팝업 컴포넌트에 전달하는 방식으로 구현했습니다.

## 👀 스크린샷 / GIF / 링크
https://naegasogaeseo-dev.kro.kr/team/0

|UI 변경 전|UI 변경 후|UI 미확정|
|-|-|-|
|<img src="https://user-images.githubusercontent.com/58380158/149534442-0a223420-8e70-4274-a90d-edfc76d47778.png" width="200px">|<img src="https://user-images.githubusercontent.com/58380158/149569504-6d468a14-9f34-452d-95b8-a280f359f88e.png" width="200px">|<img src="https://user-images.githubusercontent.com/58380158/149570035-185ca5fd-731f-4d1b-87c0-c3bfac52bde3.png" width="200px">|