### PR TITLE
private router 처리하기

### DIFF
--- a/src/presentation/routes/HomeRouter.tsx
+++ b/src/presentation/routes/HomeRouter.tsx
@@ -2,13 +2,16 @@ import { Route, Routes } from 'react-router-dom';
 import HomeMyPage from '@pages/Home/MyPage';
 import HomeTeam from '@pages/Home/Team';
 import HomeNeoga from '@pages/Home/Neoga';
+import PrivateRoute from './common/PrivateRoute';
 
 function HomeRouter() {
   return (
     <Routes>
-      <Route path="/" element={<HomeNeoga />} />
-      <Route path="neoga" element={<HomeNeoga />} />
-      <Route path="team" element={<HomeTeam />} />
+      <Route path="/" element={<PrivateRoute />}>
+        <Route path="/" element={<HomeNeoga />} />
+        <Route path="neoga" element={<HomeNeoga />} />
+        <Route path="team" element={<HomeTeam />} />
+      </Route>
       <Route path="mypage/:userID" element={<HomeMyPage />} />
     </Routes>
   );

--- a/src/presentation/routes/NeogaRouter.tsx
+++ b/src/presentation/routes/NeogaRouter.tsx
@@ -3,14 +3,17 @@ import NeogaCreate from '@pages/Neoga/Create';
 import FormDetail from '@pages/Neoga/FormDetail';
 import NeogaLink from '@pages/Neoga/Link';
 import NeogaLinkResult from '@pages/Neoga/Link/Result';
+import PrivateRoute from './common/PrivateRoute';
 
 function NeogaRouter() {
   return (
     <Routes>
-      <Route path="/create" element={<NeogaCreate />} />
-      <Route path="/:formID/detail/form" element={<FormDetail />} />
-      <Route path="/create/:formID" element={<NeogaLink />} />
-      <Route path="/create/:formID/:type" element={<NeogaLinkResult />} />
+      <Route path="/" element={<PrivateRoute />}>
+        <Route path="/create" element={<NeogaCreate />} />
+        <Route path="/:formID/detail/form" element={<FormDetail />} />
+        <Route path="/create/:formID" element={<NeogaLink />} />
+        <Route path="/create/:formID/:type" element={<NeogaLinkResult />} />
+      </Route>
     </Routes>
   );
 }

--- a/src/presentation/routes/TeamRouter.tsx
+++ b/src/presentation/routes/TeamRouter.tsx
@@ -6,16 +6,19 @@ import TeamMain from '@pages/Team/Main';
 import TeamRegister from '@pages/Team/Register';
 import TeamRegisterMembers from '@pages/Team/Register/Members';
 import { Route, Routes } from 'react-router-dom';
+import PrivateRoute from './common/PrivateRoute';
 
 const TeamRouter = () => (
   <Routes>
-    <Route path="/register" element={<TeamRegister />} />
-    <Route path="/register/members" element={<TeamRegisterMembers />} />
-    <Route path="/:teamID" element={<TeamMain />} />
-    <Route path="/:teamID/create" element={<TeamNewIssue />} />
-    <Route path="/:teamID/:issueID/*" element={<TeamIssue />}>
-      <Route path="create/*" element={<TeamIssueFeedback />}>
-        <Route path="keyword" element={<TeamIssueKeyword />} />
+    <Route path="/" element={<PrivateRoute />}>
+      <Route path="/register" element={<TeamRegister />} />
+      <Route path="/register/members" element={<TeamRegisterMembers />} />
+      <Route path="/:teamID" element={<TeamMain />} />
+      <Route path="/:teamID/create" element={<TeamNewIssue />} />
+      <Route path="/:teamID/:issueID/*" element={<TeamIssue />}>
+        <Route path="create/*" element={<TeamIssueFeedback />}>
+          <Route path="keyword" element={<TeamIssueKeyword />} />
+        </Route>
       </Route>
     </Route>
   </Routes>

--- a/src/presentation/routes/UserRouter.tsx
+++ b/src/presentation/routes/UserRouter.tsx
@@ -11,7 +11,6 @@ const LoginRouter = () => (
     <Route path="/join" element={<Join />} />
     <Route path="/joinComplete" element={<JoinComplete />} />
     <Route path="/home/*" element={<Home />} />
-
     <Route path="/auth/kakao/callback" element={<OAuthRedirectHandler />} />
   </Routes>
 );

--- a/src/presentation/routes/common/PrivateRoute.tsx
+++ b/src/presentation/routes/common/PrivateRoute.tsx
@@ -1,0 +1,9 @@
+import { useLoginUser } from '@hooks/useLoginUser';
+import { Navigate, Outlet } from 'react-router-dom';
+
+function PrivateRoute() {
+  const { isAuthenticated, isLoading } = useLoginUser();
+  return isLoading ? <></> : isAuthenticated ? <Outlet /> : <Navigate to="/" />;
+}
+
+export default PrivateRoute;


### PR DESCRIPTION
## ⛓ Related Issues
- close #111 

## 📋 작업 내용
- [x] private router 만들기
- [x] 회원가입, 로그인, 렌딩, 마이페이지 제외하고 모두 private router 안에 가두기

## 📌 PR Point
- 이제 로그인 안 하면 회원가입, 로그인, 렌딩, 마이페이지 제외하고 접근 못 한다!
- 대신 한번이라도 로그인 했다면 다 접근할 수 있다!
- 리라돔 v6에서는 Routes의 자식으로 Route가 아닌 친구를 둘 수가 없어서 이렇게 했읍니다.. 모든 스택오버플로우에서 이 방법밖에 없다고 함 ㅜㅜ

이 파일이 제일 중요함!
```tsx
import { useLoginUser } from '@hooks/useLoginUser';
import { Navigate, Outlet } from 'react-router-dom';

function PrivateRoute() {
  const { isAuthenticated, isLoading } = useLoginUser();
  return isLoading ? <></> : isAuthenticated ? <Outlet /> : <Navigate to="/" />;
}

export default PrivateRoute;
```

## 🔬 Reference
- https://flutterq.com/error-privateroute-is-not-a-component-all-component-children-of-must-be-a-or/
- https://devalice.tistory.com/112
- https://gaemi606.tistory.com/entry/React-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%A0%95%EB%B3%B4-%EC%97%86%EC%9D%84-%EA%B2%BD%EC%9A%B0-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%A1%9C-redirect%ED%95%98%EA%B8%B0-react-router-PrivateRoute

