### PR TITLE
레이지로딩 적용

### DIFF
--- a/src/presentation/routes/FormRouter.tsx
+++ b/src/presentation/routes/FormRouter.tsx
@@ -3,7 +3,7 @@ import { lazy } from 'react';
 const NeososeoFormAnswer = lazy(() => import('@pages/NeososeoForm/Answer'));
 const NeososeoFormHome = lazy(() => import('@pages/NeososeoForm/Home'));
 const NeososeoFormIntro = lazy(() => import('@pages/NeososeoForm/Intro'));
-const TeamIssueKeyword = lazy(() => import('@pages/Team/Issue/Keyword'));
+import TeamIssueKeyword from '@pages/Team/Issue/Keyword';
 
 function FormRouter() {
   return (

--- a/src/presentation/routes/FormRouter.tsx
+++ b/src/presentation/routes/FormRouter.tsx
@@ -1,8 +1,9 @@
-import NeososeoFormAnswer from '@pages/NeososeoForm/Answer';
-import NeososeoFormHome from '@pages/NeososeoForm/Home';
-import NeososeoFormIntro from '@pages/NeososeoForm/Intro';
-import TeamIssueKeyword from '@pages/Team/Issue/Keyword';
 import { Route, Routes } from 'react-router-dom';
+import { lazy } from 'react';
+const NeososeoFormAnswer = lazy(() => import('@pages/NeososeoForm/Answer'));
+const NeososeoFormHome = lazy(() => import('@pages/NeososeoForm/Home'));
+const NeososeoFormIntro = lazy(() => import('@pages/NeososeoForm/Intro'));
+const TeamIssueKeyword = lazy(() => import('@pages/Team/Issue/Keyword'));
 
 function FormRouter() {
   return (

--- a/src/presentation/routes/HomeRouter.tsx
+++ b/src/presentation/routes/HomeRouter.tsx
@@ -1,8 +1,9 @@
 import { Route, Routes } from 'react-router-dom';
-import HomeMyPage from '@pages/Home/MyPage';
-import HomeTeam from '@pages/Home/Team';
-import HomeNeoga from '@pages/Home/Neoga';
-import PrivateRoute from './common/PrivateRoute';
+import { lazy } from 'react';
+const HomeMyPage = lazy(() => import('@pages/Home/MyPage'));
+const HomeTeam = lazy(() => import('@pages/Home/Team'));
+const HomeNeoga = lazy(() => import('@pages/Home/Neoga'));
+const PrivateRoute = lazy(() => import('./common/PrivateRoute'));
 
 function HomeRouter() {
   return (

--- a/src/presentation/routes/NeogaRouter.tsx
+++ b/src/presentation/routes/NeogaRouter.tsx
@@ -1,10 +1,11 @@
 import { Route, Routes } from 'react-router-dom';
-import NeogaCreate from '@pages/Neoga/Create';
-import NeogaResult from '@pages/Neoga/Result';
-import FormDetail from '@pages/Neoga/FormDetail';
-import NeogaLink from '@pages/Neoga/Link';
-import NeogaLinkResult from '@pages/Neoga/Link/Result';
-import PrivateRoute from './common/PrivateRoute';
+import { lazy } from 'react';
+const NeogaCreate = lazy(() => import('@pages/Neoga/Create'));
+const NeogaResult = lazy(() => import('@pages/Neoga/Result'));
+const FormDetail = lazy(() => import('@pages/Neoga/FormDetail'));
+const NeogaLink = lazy(() => import('@pages/Neoga/Link'));
+const NeogaLinkResult = lazy(() => import('@pages/Neoga/Link/Result'));
+const PrivateRoute = lazy(() => import('./common/PrivateRoute'));
 
 function NeogaRouter() {
   return (

--- a/src/presentation/routes/Router.tsx
+++ b/src/presentation/routes/Router.tsx
@@ -1,6 +1,7 @@
 import ScrollToTop from '@components/common/ScrollToTop';
 import NeososeoFormPage from '@pages/NeososeoForm';
 import NeososeoFormFinish from '@pages/NeososeoForm/Finish';
+import { Suspense } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import NeogaRouter from './NeogaRouter';
 import TeamRouter from './TeamRouter';
@@ -10,13 +11,15 @@ const Router = () => {
   return (
     <BrowserRouter>
       <ScrollToTop />
-      <Routes>
-        <Route path="/*" element={<UserRouter />} />
-        <Route path="/team/*" element={<TeamRouter />} />
-        <Route path="/neoga/*" element={<NeogaRouter />} />
-        <Route path="/neososeoform/:q/*" element={<NeososeoFormPage />} />
-        <Route path="/neososeoform/:q/finish" element={<NeososeoFormFinish />} />
-      </Routes>
+      <Suspense fallback={<></>}>
+        <Routes>
+          <Route path="/*" element={<UserRouter />} />
+          <Route path="/team/*" element={<TeamRouter />} />
+          <Route path="/neoga/*" element={<NeogaRouter />} />
+          <Route path="/neososeoform/:q/*" element={<NeososeoFormPage />} />
+          <Route path="/neososeoform/:q/finish" element={<NeososeoFormFinish />} />
+        </Routes>
+      </Suspense>
     </BrowserRouter>
   );
 };

--- a/src/presentation/routes/TeamRouter.tsx
+++ b/src/presentation/routes/TeamRouter.tsx
@@ -1,9 +1,9 @@
 import { Route, Routes } from 'react-router-dom';
 import { lazy } from 'react';
 import PrivateRoute from './common/PrivateRoute';
+import TeamIssueFeedback from '@pages/Team/Issue/Feedback';
+import TeamIssueKeyword from '@pages/Team/Issue/Keyword';
 const TeamIssue = lazy(() => import('@pages/Team/Issue'));
-const TeamIssueFeedback = lazy(() => import('@pages/Team/Issue/Feedback'));
-const TeamIssueKeyword = lazy(() => import('@pages/Team/Issue/Keyword'));
 const TeamNewIssue = lazy(() => import('@pages/Team/Issue/NewIssue'));
 const TeamMain = lazy(() => import('@pages/Team/Main'));
 const TeamRegister = lazy(() => import('@pages/Team/Register'));

--- a/src/presentation/routes/TeamRouter.tsx
+++ b/src/presentation/routes/TeamRouter.tsx
@@ -1,12 +1,13 @@
-import TeamIssue from '@pages/Team/Issue';
-import TeamIssueFeedback from '@pages/Team/Issue/Feedback';
-import TeamIssueKeyword from '@pages/Team/Issue/Keyword';
-import TeamNewIssue from '@pages/Team/Issue/NewIssue';
-import TeamMain from '@pages/Team/Main';
-import TeamRegister from '@pages/Team/Register';
-import TeamRegisterMembers from '@pages/Team/Register/Members';
 import { Route, Routes } from 'react-router-dom';
+import { lazy } from 'react';
 import PrivateRoute from './common/PrivateRoute';
+const TeamIssue = lazy(() => import('@pages/Team/Issue'));
+const TeamIssueFeedback = lazy(() => import('@pages/Team/Issue/Feedback'));
+const TeamIssueKeyword = lazy(() => import('@pages/Team/Issue/Keyword'));
+const TeamNewIssue = lazy(() => import('@pages/Team/Issue/NewIssue'));
+const TeamMain = lazy(() => import('@pages/Team/Main'));
+const TeamRegister = lazy(() => import('@pages/Team/Register'));
+const TeamRegisterMembers = lazy(() => import('@pages/Team/Register/Members'));
 
 const TeamRouter = () => (
   <Routes>

--- a/src/presentation/routes/UserRouter.tsx
+++ b/src/presentation/routes/UserRouter.tsx
@@ -1,12 +1,13 @@
 import { Route, Routes } from 'react-router-dom';
-import Landing from '@pages/Landing';
-import Login from '@pages/Login';
-import Join from '@pages/Join';
-import OAuthRedirectHandler from '@pages/OAuthRedirectHandler';
-import Home from '@pages/Home';
-import JoinComplete from '@pages/JoinComplete';
+import { lazy } from 'react';
+const Login = lazy(() => import('@pages/Login'));
+const Join = lazy(() => import('@pages/Join'));
+const OAuthRedirectHandler = lazy(() => import('@pages/OAuthRedirectHandler'));
+const Home = lazy(() => import('@pages/Home'));
+const JoinComplete = lazy(() => import('@pages/JoinComplete'));
+const Landing = lazy(() => import('@pages/Landing'));
 
-const LoginRouter = () => (
+const UserRouter = () => (
   <Routes>
     <Route path="/" element={<Landing />} />
     <Route path="/login" element={<Login />} />
@@ -17,4 +18,4 @@ const LoginRouter = () => (
   </Routes>
 );
 
-export default LoginRouter;
+export default UserRouter;


### PR DESCRIPTION
## ⛓ Related Issues
- close #131

## 📋 작업 내용
- [x] 페이지 로드 시 레이지 로딩 적용
- [x] 에러 나는 부분은 레이지 로딩 빼기

## 📌 PR Point
```ts
const HomeMyPage = lazy(() => import('@pages/Home/MyPage'));
const HomeTeam = lazy(() => import('@pages/Home/Team'));
const HomeNeoga = lazy(() => import('@pages/Home/Neoga'));
const PrivateRoute = lazy(() => import('./common/PrivateRoute'));
```
이런식으로 import하면 쪼개서 번들링되고, 그럼 사이트 초기 로딩 시간이 조금이라도 더 빨라질 수 있을 것입니다!

랜딩만 보고 나가는 사람들이 굳이 우리 사이트의 모든 자원에 대한 Js파일을 받을 필요가 없어서 저렇게 해두었습니다

## 🔬 Reference
https://stackoverflow.com/questions/69949256/lazy-loading-in-react-router-dom-v6-0-2