### PR TITLE
카카오 로그인 redirect uri 변경

### DIFF
--- a/src/application/utils/constant.ts
+++ b/src/application/utils/constant.ts
@@ -1,1 +1,2 @@
-export const DOMAIN = 'http://naegasogaeseo.kro.kr/';
+export const isProduction = process.env.NODE_ENV === 'production';
+export const DOMAIN = isProduction ? 'http://localhost:3000/' : 'https://neogasogaeseo.com/';

--- a/src/presentation/components/LoginForm/OAuth.ts
+++ b/src/presentation/components/LoginForm/OAuth.ts
@@ -1,4 +1,6 @@
+import { DOMAIN } from '@utils/constant';
+
 const CLIENT_ID = `${process.env.REACT_APP_CLIENT_ID}`;
-const REDIRECT_URI = 'http://localhost:3000/auth/kakao/callback';
+const REDIRECT_URI = `${DOMAIN}/auth/kakao/callback`;
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;

--- a/src/presentation/components/NeogaDetailForm/index.tsx
+++ b/src/presentation/components/NeogaDetailForm/index.tsx
@@ -29,6 +29,7 @@ import {
   StMoreButton,
   StIcon,
 } from './style';
+import { DOMAIN } from '@utils/constant';
 
 function NeogaDetailForm() {
   const { formID } = useParams();
@@ -36,7 +37,7 @@ function NeogaDetailForm() {
   const [resultFeedback, setResultFeedback] = useState<ResultFeedList | null>(null);
   const [resultBoolean, setResultBoolean] = useState(false);
   const [lookMoreButton, setLookMoreButton] = useState(false);
-  const link = `www.neogasogaeseo.com/neososeoform/${resultKeywordList && resultKeywordList.q}`;
+  const link = `${DOMAIN}/neososeoform/${resultKeywordList && resultKeywordList.q}`;
   const { fireToast } = useToast();
 
   useEffect(() => {

--- a/src/presentation/pages/Neoga/Link/Result/index.tsx
+++ b/src/presentation/pages/Neoga/Link/Result/index.tsx
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 import { useToast } from '@hooks/useToast';
 import { api } from '@api/index';
 import { useState } from 'react';
+import { DOMAIN } from '@utils/constant';
 
 export default function NeogaLinkResult() {
   const { formID, type } = useParams();
@@ -20,7 +21,7 @@ export default function NeogaLinkResult() {
     const q = await api.neogaService.postCreateForm(Number(formID), () =>
       navigate(`/neoga/create/${formID}/created`),
     );
-    setLink(`https://neogasogaeseo.com/neososeoform/${q}`);
+    setLink(`${DOMAIN}/neososeoform/${q}`);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## ⛓ Related Issues
- close #132

## 📋 작업 내용
- [x] process.env.NODE_ENV 읽기
- [x] 도메인 삼항연산자 때리기

## 📌 PR Point
```ts
export const isProduction = process.env.NODE_ENV === 'production';
export const DOMAIN = isProduction ? 'http://localhost:3000/' : 'https://neogasogaeseo.com/';
```
이렇게 한 이후, 우리 도메인 쓰는 부분들은 다 `${DOMAIN}` 넣어 놨습니당

## Reference
https://ui.toast.com/weekly-pick/ko_20191212
https://github.com/pa-rang/kyrics-frontend/blob/main/lib/constants/env.ts
