### PR TITLE
너소서 피드백 put API 붙이기

### DIFF
--- a/src/infrastructure/api/types/neoga.ts
+++ b/src/infrastructure/api/types/neoga.ts
@@ -78,12 +78,5 @@ export type FeedAnswer = {
   content: string;
   isPinned: boolean;
   createdAt: string;
-  keywords: AnswerKeyword[];
-};
-
-export type AnswerKeyword = {
-  id: number;
-  name: string;
-  colorcode: string;
-  answerId: number;
+  keywords: Keyword[];
 };

--- a/src/infrastructure/remote/neoga.ts
+++ b/src/infrastructure/remote/neoga.ts
@@ -138,9 +138,9 @@ export function NeogaDataRemote(): NeogaService {
     return NEOGA_DATA.NEOGA_RESULT;
   };
 
-  const postAnswerBookmark = async () => {
-    await wait(1000);
-    return { isSuccess: true };
+  const postAnswerBookmark = async (answerID: number) => {
+    const response = await privateAPI.put({ url: `/form/detail/answer/${answerID}/pin` });
+    return { isSuccess: response.success };
   };
 
   const postCreateForm = async (formID: number) => {

--- a/src/presentation/components/NeogaDetailForm/Card/index.tsx
+++ b/src/presentation/components/NeogaDetailForm/Card/index.tsx
@@ -1,0 +1,51 @@
+import { api } from '@api/index';
+import { FeedAnswer } from '@api/types/neoga';
+import { icBookmarkSelected, icBookmarkUnselected } from '@assets/icons';
+import ImmutableKeywordList from '@components/common/Keyword/ImmutableList';
+import { useState } from 'react';
+import {
+  StFeedContent,
+  StFeedDate,
+  StFeedHeader,
+  StFeedName,
+  StNeogaDetailFormCard,
+} from '../style';
+
+type NeogaDetailFormCardProps = FeedAnswer;
+
+function NeogaDetailFormCard(props: NeogaDetailFormCardProps) {
+  const { id, name, relationship, content, createdAt, keywords } = props;
+  const [isBookmarked, setIsBookmarked] = useState(props.isPinned);
+
+  const bookmarkAnswer = async () => {
+    const response = await api.neogaService.postAnswerBookmark(id);
+    if (response.isSuccess) setIsBookmarked((prev) => !prev);
+  };
+
+  return (
+    <StNeogaDetailFormCard>
+      <StFeedHeader>
+        <StFeedName>
+          {name}
+          <p>·</p>
+          <span>너를 {relationship}</span>
+        </StFeedName>
+        <div>
+          <StFeedDate>
+            <div>{createdAt}</div>
+            <img
+              src={isBookmarked ? icBookmarkSelected : icBookmarkUnselected}
+              alt="bookmark"
+              onClick={bookmarkAnswer}
+            />
+          </StFeedDate>
+        </div>
+      </StFeedHeader>
+      <StFeedContent>{content}</StFeedContent>
+      <ImmutableKeywordList keywordList={keywords} onItemClick={() => null} />
+      <hr />
+    </StNeogaDetailFormCard>
+  );
+}
+
+export default NeogaDetailFormCard;

--- a/src/presentation/components/NeogaDetailForm/index.tsx
+++ b/src/presentation/components/NeogaDetailForm/index.tsx
@@ -13,14 +13,9 @@ import {
   StNeogaDetailForm,
   StDate,
   StKeyword,
-  StFeedWrapper,
-  StFeedHeader,
-  StFeedContent,
   StFeedTitle,
   StQuestion,
   StLink,
-  StFeedName,
-  StFeedDate,
   StEmptyFeedback,
   StButton,
   StMoreWrapper,
@@ -28,6 +23,7 @@ import {
 } from './style';
 import { DOMAIN } from '@utils/constant';
 import NeososeoFormHeader from '@components/common/NeososeoFormHeader';
+import NeogaDetailFormCard from './Card';
 
 function NeogaDetailForm() {
   const { formID } = useParams();
@@ -127,25 +123,9 @@ function NeogaDetailForm() {
         <span>{resultFeedback ? resultFeedback.answerCount : 0}개</span>의 답변 피드
       </StFeedTitle>
       {resultFeedback && resultFeedback.answer.length > 0 ? (
-        resultFeedback.answer.map((feedback: any) => {
-          return (
-            <>
-              <StFeedWrapper>
-                <StFeedHeader>
-                  <StFeedName>
-                    {feedback.name}
-                    <p>·</p>
-                    <span>너를 {feedback.relationship}</span>
-                  </StFeedName>
-                  <StFeedDate>{feedback.createdAt}</StFeedDate>
-                </StFeedHeader>
-                <StFeedContent>{feedback.content}</StFeedContent>
-                <ImmutableKeywordList keywordList={feedback.keywords} onItemClick={() => null} />
-                <hr />
-              </StFeedWrapper>
-            </>
-          );
-        })
+        resultFeedback.answer.map((feedback) => (
+          <NeogaDetailFormCard key={feedback.id} {...feedback} />
+        ))
       ) : (
         <StEmptyFeedback>
           <img src={imgEmptyFeedback} alt="" />

--- a/src/presentation/components/NeogaDetailForm/style.ts
+++ b/src/presentation/components/NeogaDetailForm/style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { COLOR } from '@styles/common/color';
+import { FONT_STYLES } from '@styles/common/font-style';
 
 export const StNeogaDetailForm = styled.div`
   & > hr {
@@ -90,9 +91,18 @@ export const StKeyword = styled.div`
 
 export const StFeedDate = styled.div`
   color: ${COLOR.GRAY_4};
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  & div {
+    ${FONT_STYLES.R_14_TITLE}
+  }
+  & img {
+    width: 22px;
+  }
 `;
 
-export const StFeedWrapper = styled.div`
+export const StNeogaDetailFormCard = styled.div`
   margin: 0 20px 0 20px;
   & > hr {
     margin-top: 24px;

--- a/src/presentation/pages/Home/MyPage/index.tsx
+++ b/src/presentation/pages/Home/MyPage/index.tsx
@@ -24,6 +24,7 @@ import {
   StMyPageProfile,
 } from './style';
 import MyEmptyView from '@components/common/Empty/MyPage';
+import { DOMAIN } from '@utils/constant';
 
 function HomeMyPage() {
   const { userID } = useParams();
@@ -80,7 +81,7 @@ function HomeMyPage() {
             {isMyPage && (
               <StShare
                 onClick={() =>
-                  copyClipboard(pathname, () =>
+                  copyClipboard(`${DOMAIN}${pathname}`, () =>
                     fireToast({ content: '링크가 클립보드에 저장되었습니다.' }),
                   )
                 }

--- a/src/presentation/pages/Home/MyPage/index.tsx
+++ b/src/presentation/pages/Home/MyPage/index.tsx
@@ -115,7 +115,7 @@ function HomeMyPage() {
               <span>{neososeoBookmark.count}</span>
             </div>
             {isMyPage && (
-              <StDetailLink to="/home/neoga">
+              <StDetailLink to="/neoga/result">
                 <span>전체보기</span>
                 <IcArrowViewAll />
               </StDetailLink>
@@ -127,7 +127,7 @@ function HomeMyPage() {
             <MyEmptyView
               isMyPage={isMyPage}
               origin="너가소개서"
-              onPickButtonClicked={() => navigate('/home/neoga')}
+              onPickButtonClicked={() => navigate('/neoga/result')}
             />
           )}
         </div>


### PR DESCRIPTION
## ⛓ Related Issues
- close #149 

## 📋 작업 내용
- [x] 너소서 피드백을 저장하는 API를 붙였습니다!
- [x] 너소서 결과 페이지에서 카드 아이템을 별도의 컴포넌트로 분리했습니다. 

## 📌 PR Point
- 너소서 결과 페이지에서 카드 아이템을 별도 컴포넌트로 분리한 이유는 "북마크된 상태"를 따로 관리하고 싶어서, 북마크 요청 자체는 그 컴포넌트 안에서 관리하고 싶어서입니다. 
- 똑같은 온클릭 리스너가 너무 많이 붙어 있게 되어 걱정이 되지만, 리액트가 알아서 이벤트 위임을 해주리라 믿고 있습니다. 
