### PR TITLE
google analytics 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lottie-web": "^5.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-ga": "^3.3.0",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
     "recoil": "^0.5.2",

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,15 @@
     <meta property="og:url" content="https://www.neogasogaeseo.com/" />
     <title>너가소개서</title>
     <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-4DZZ8ZJJYS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-4DZZ8ZJJYS');
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,9 @@ import Router from '@routes/Router';
 import { useLoginUser } from '@hooks/useLoginUser';
 import { useEffect } from 'react';
 import ToastList from '@components/common/Toast/List';
+import { useLocation } from 'react-router-dom';
+import { useGoogleAnalytics } from '@hooks/useGoogleAnalytics';
+import ReactGA from 'react-ga';
 
 function App() {
   const { initLoginUser } = useLoginUser();
@@ -10,6 +13,13 @@ function App() {
   useEffect(() => {
     initLoginUser();
   }, []);
+
+  const location = useLocation();
+  const { isGoogleAnalyticsLoaded } = useGoogleAnalytics();
+
+  useEffect(() => {
+    if (isGoogleAnalyticsLoaded) ReactGA.pageview(location.pathname + location.search);
+  }, [isGoogleAnalyticsLoaded, location]);
 
   return (
     <>

--- a/src/application/hooks/useGoogleAnalytics.ts
+++ b/src/application/hooks/useGoogleAnalytics.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import ReactGA from 'react-ga';
+
+export function useGoogleAnalytics() {
+  const [isGoogleAnalyticsLoaded, setIsGoogleAnalyticsLoaded] = useState(false);
+
+  useEffect(() => {
+    ReactGA.initialize('G-4DZZ8ZJJYS');
+    setIsGoogleAnalyticsLoaded(true);
+  }, []);
+
+  return { isGoogleAnalyticsLoaded };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7169,6 +7169,11 @@ react-error-overlay@^6.0.10:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"
   integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
 
+react-ga@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.0.tgz#c91f407198adcb3b49e2bc5c12b3fe460039b3ca"
+  integrity sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
## ⛓ Related Issues
- close #166 

## 📋 작업 내용
- [x] google analytics 설치 => 풀 받은 이후 yarn 한 번 때려 줘야 함

## 📌 PR Point
- 머지 이후에 변화가 생길 듯!
- 현재 접속한 사용자 수, 페이지 조회수, 스크롤 수, 새 사용자 수 등의 정보를 받을 수 있음
- 더 많은 사용자 이벤트를 제공받고 싶다면 코드를 추가해야 함

## 🔬 Reference
https://velog.io/@alvin/Rsum-6.-react-ga%EB%A1%9C-Google-Analytics-%EB%B6%99%EC%9D%B4%EA%B8%B0