### PR TITLE
팀원 검색 뷰에서 Enter 키 입력 시 검색되도록 하기 (CommonInput 컴포넌트 수정)

### DIFF
--- a/src/presentation/components/TeamMembersSearchBar/index.tsx
+++ b/src/presentation/components/TeamMembersSearchBar/index.tsx
@@ -25,15 +25,13 @@ export default function TeamMembersSearchBar(props: TeamMembersSearchBarProps) {
         onChange={() =>
           userSearchWordRef.current && setUserSearchWord(userSearchWordRef.current.value)
         }
+        onSubmit={() => {
+          onClickSearchButton();
+          userSearchWordRef.current && (userSearchWordRef.current.value = '');
+        }}
         placeholder="팀원 검색하기"
         width="100%"
-        submitButton={{
-          value: '검색',
-          onClick: () => {
-            onClickSearchButton();
-            userSearchWordRef.current && (userSearchWordRef.current.value = '');
-          },
-        }}
+        submitButtonValue="검색"
         img={icSearch}
       />
       {selectedUserList && (

--- a/src/presentation/components/TeamMembersSearchBar/index.tsx
+++ b/src/presentation/components/TeamMembersSearchBar/index.tsx
@@ -7,17 +7,14 @@ import CommonInput from '@components/common/CommonInput';
 import { icSearch } from '@assets/icons';
 import { useRef } from 'react';
 
-interface TeamMembersSearchBarProps {
-  onClickSearchButton: () => Promise<void>;
-  onKeypressSearchInput: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-}
-
-export default function TeamMembersSearchBar(props: TeamMembersSearchBarProps) {
-  const { onClickSearchButton, onKeypressSearchInput } = props;
+export default function TeamMembersSearchBar({
+  onSubmitSearch,
+}: {
+  onSubmitSearch: () => Promise<void>;
+}) {
   const [selectedUserList, setSelectedUserList] = useRecoilState(selectedUserListState);
   const setUserSearchWord = useSetRecoilState(userSearchWordState);
   const userSearchWordRef = useRef<HTMLInputElement>(null);
-  console.log(onKeypressSearchInput);
   return (
     <StTeamMembersSearchBar>
       <CommonInput
@@ -26,7 +23,7 @@ export default function TeamMembersSearchBar(props: TeamMembersSearchBarProps) {
           userSearchWordRef.current && setUserSearchWord(userSearchWordRef.current.value)
         }
         onSubmit={() => {
-          onClickSearchButton();
+          onSubmitSearch();
           userSearchWordRef.current && (userSearchWordRef.current.value = '');
         }}
         placeholder="팀원 검색하기"

--- a/src/presentation/components/common/CommonInput/index.tsx
+++ b/src/presentation/components/common/CommonInput/index.tsx
@@ -10,12 +10,9 @@ interface CommonInputProps {
   isConditionMet?: boolean;
   img?: string;
   onChange?: (value: string) => void;
-  onKeyPress?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
   disabled?: boolean;
-  submitButton?: {
-    value: string;
-    onClick: () => void;
-  };
+  submitButtonValue?: string;
   inputRef?: React.RefObject<HTMLInputElement>;
 }
 
@@ -29,10 +26,10 @@ const CommonInput = React.forwardRef<HTMLInputElement, CommonInputProps>(
       value,
       isConditionMet,
       onChange,
-      onKeyPress,
+      onSubmit,
       img,
       disabled = false,
-      submitButton,
+      submitButtonValue,
     } = props;
     const [isInput, setIsInput] = useState('');
 
@@ -42,22 +39,25 @@ const CommonInput = React.forwardRef<HTMLInputElement, CommonInputProps>(
     }
     return (
       <StCommonInput>
-        <StInputWrapper width={width}>
+        <StInputWrapper
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmit && onSubmit(e);
+          }}
+          width={width}
+        >
           <StInput
             width={width}
             onChange={handleOnChange}
-            onKeyPress={(e) => onKeyPress && onKeyPress(e)}
             maxLength={maxLength}
             placeholder={placeholder || ''}
             value={value}
             img={img}
             disabled={disabled}
-            hasButton={submitButton !== undefined}
+            hasButton={submitButtonValue !== undefined}
             ref={ref}
           />
-          {submitButton && (
-            <StSubmitButton onClick={submitButton.onClick}>{submitButton.value}</StSubmitButton>
-          )}
+          {submitButtonValue && <StSubmitButton>{submitButtonValue}</StSubmitButton>}
         </StInputWrapper>
         {!isConditionMet && isInput !== '' && errorMsg && <StErrorMsg>{errorMsg}</StErrorMsg>}
       </StCommonInput>

--- a/src/presentation/components/common/CommonInput/style.ts
+++ b/src/presentation/components/common/CommonInput/style.ts
@@ -34,15 +34,15 @@ export const StErrorMsg = styled.div`
   margin-top: 15px;
 `;
 
-export const StSubmitButton = styled.div`
+export const StSubmitButton = styled.button`
   position: absolute;
-  right: 14px;
-  top: 14px;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  right: 16px;
+  top: calc(50%-26px);
+  height: 26px;
   padding-left: 12px;
   border-left: 1px solid ${COLOR.GRAY_3};
   color: ${COLOR.GRAY_7};
   cursor: pointer;
+  background-color: transparent;
   ${FONT_STYLES.M_15_TITLE}
 `;

--- a/src/presentation/components/common/CommonInput/style.ts
+++ b/src/presentation/components/common/CommonInput/style.ts
@@ -8,7 +8,7 @@ export const StCommonInput = styled.div`
   flex-direction: column;
 `;
 
-export const StInputWrapper = styled.div<{ width: string }>`
+export const StInputWrapper = styled.form<{ width: string }>`
   display: flex;
   align-items: center;
   width: ${(props) => props.width};

--- a/src/presentation/pages/Team/Issue/Keyword/index.tsx
+++ b/src/presentation/pages/Team/Issue/Keyword/index.tsx
@@ -50,7 +50,8 @@ function TeamIssueKeyword() {
           placeholder="새로 입력하고 싶은 키워드를 작성해주세요"
           value={newKeywordContent}
           onChange={(value: string) => setNewKeywordContent(value)}
-          submitButton={{ value: '생성', onClick: createKeyword }}
+          onSubmit={createKeyword}
+          submitButtonValue="생성"
         />
         <MutableKeywordList keywordList={keywordList} deleteKeyword={removeKeyword} />
       </StWhiteWrapper>

--- a/src/presentation/pages/Team/Register/Members/index.tsx
+++ b/src/presentation/pages/Team/Register/Members/index.tsx
@@ -72,12 +72,7 @@ export default function TeamRegisterMembers() {
         <div>팀원 추가</div>
         <button onClick={() => history.back()}>완료</button>
       </StHeader>
-      <TeamMembersSearchBar
-        onClickSearchButton={searchUser}
-        onKeypressSearchInput={(e: React.KeyboardEvent<HTMLInputElement>) => {
-          if (e.key === 'Enter') searchUser();
-        }}
-      />
+      <TeamMembersSearchBar onSubmitSearch={searchUser} />
       <StTeamMembersSearchResultTitle>검색결과</StTeamMembersSearchResultTitle>
       {searchedUserList.map((user) => {
         const { id, profileId, profileName, profileImage = imgEmptyProfile, isAdded } = user;


### PR DESCRIPTION
## ⛓ Related Issues
- close #173 

## 📋 작업 내용
<img width="400" src="https://user-images.githubusercontent.com/73823388/152685138-6c8db4e8-6f54-4a8f-b3d2-dc9521b1fb60.png" />

커밋 단위 잘 나눠서 요것 보시면 됩니다 

++++++
버튼 테스트를 빼먹고 말았네유ㅠㅠ 바부바보..
안되길래 보니 button이 아니라 div여서 수정했습니다
근데 위치가 살짝 내려가버리길래 위치 조정 아예 다른 방법으로 해봤어요!


## 📌 PR Point
- CommonInput의 click or keypress 이벤트를 쓰고 있던 곳은 팀원 검색 뷰, 키워드 생성 뷰였는데 둘다 문제 없이 작동하는 것 확인했습니다!
- form 태그로 바꾸고 혹시 깨지는 스타일 같은 것은 없는지 CommonInput 쓰고 있는 페이지 골고루 확인했습니다!