### PR TITLE
너가소개서 결과 페이지 에러 해결

### DIFF
--- a/src/infrastructure/remote/neoga-result.ts
+++ b/src/infrastructure/remote/neoga-result.ts
@@ -26,20 +26,22 @@ export const getNeogaFeedbackResult = async (
   if (response.status === 200 && response.data)
     return {
       answerCount: response.data.answerCount,
-      answer: response.data.answer.map((feedback: any) => ({
-        formID: feedback.formID,
-        id: feedback.id,
-        name: feedback.name,
-        relationship: feedback.relationship,
-        content: feedback.content,
-        isPinned: feedback.isPinned,
-        createdAt: feedback.createdAt,
-        keywords: feedback.keywords.map((keyword: any) => ({
-          id: keyword.id,
-          content: keyword.name,
-          color: keyword.colorcode,
-          answerId: keyword.answerId,
-        })),
-      })),
+      answer: response.data.answer
+        ? response.data.answer.map((feedback: any) => ({
+            formID: feedback.formID,
+            id: feedback.id,
+            name: feedback.name,
+            relationship: feedback.relationship,
+            content: feedback.content,
+            isPinned: feedback.isPinned,
+            createdAt: feedback.createdAt,
+            keywords: feedback.keywords.map((keyword: any) => ({
+              id: keyword.id,
+              content: keyword.name,
+              color: keyword.colorcode,
+              answerId: keyword.answerId,
+            })),
+          }))
+        : [],
     };
 };

--- a/src/presentation/components/NeogaDetailForm/index.tsx
+++ b/src/presentation/components/NeogaDetailForm/index.tsx
@@ -120,7 +120,7 @@ function NeogaDetailForm() {
       </StKeyword>
       <hr />
       <StFeedTitle>
-        <span>{resultFeedback ? resultFeedback.answerCount : 0}개</span>의 답변 피드
+        <span>{resultFeedback?.answerCount !== undefined ? resultFeedback.answerCount : 0}개</span>의 답변 피드
       </StFeedTitle>
       {resultFeedback && resultFeedback.answer.length > 0 ? (
         resultFeedback.answer.map((feedback) => (

--- a/src/presentation/components/NeogaDetailForm/index.tsx
+++ b/src/presentation/components/NeogaDetailForm/index.tsx
@@ -87,7 +87,7 @@ function NeogaDetailForm() {
         </StQuestion>
       </div>
       <StKeyword>
-        <p>키워드모음</p>
+        {resultKeywordList.keywordlists.length !== 0 && <p>키워드모음</p>}
         {!lookMoreButton && (
           <ImmutableKeywordList
             keywordList={resultKeywordList ? resultKeywordList.keywordlists.slice(0, 7) : []}

--- a/src/presentation/components/NeogaDetailForm/style.ts
+++ b/src/presentation/components/NeogaDetailForm/style.ts
@@ -4,7 +4,7 @@ import { FONT_STYLES } from '@styles/common/font-style';
 
 export const StNeogaDetailForm = styled.div`
   & > hr {
-    border: 1px solid ${COLOR.GRAY_2};
+    border: none;
     height: 8px;
     background-color: ${COLOR.GRAY_1};
   }
@@ -19,6 +19,7 @@ export const StNeogaDetailForm = styled.div`
 export const StLink = styled.div`
   display: flex;
   cursor: pointer;
+  width: fit-content;
   margin: 10px 0px 0px 20px;
   color: ${COLOR.CORAL_MAIN};
   & > img {

--- a/src/presentation/components/common/Empty/MyPage/style.ts
+++ b/src/presentation/components/common/Empty/MyPage/style.ts
@@ -42,4 +42,5 @@ export const StButton = styled.div`
   line-height: 1.44em;
   letter-spacing: -0.0015em;
   margin-top: 15px;
+  cursor: pointer;
 `;

--- a/src/presentation/components/common/Toast/Item/style.ts
+++ b/src/presentation/components/common/Toast/Item/style.ts
@@ -3,7 +3,6 @@ import { ANIMATION } from '@styles/common/animation';
 
 export const StToastItem = styled.div<{ bottom?: number; isClosing: boolean }>`
   position: absolute;
-  margin: 0 20px;
   background-color: rgb(0, 0, 0, 0.5);
   height: 40px;
   border-radius: 20px;
@@ -11,6 +10,8 @@ export const StToastItem = styled.div<{ bottom?: number; isClosing: boolean }>`
   line-height: 40px;
   color: white;
   width: 100%;
+  max-width: 350px;
+  margin: 0 auto;
   bottom: ${({ bottom }) => bottom ?? 26}px;
   animation: 0.3s forwards
     ${({ isClosing }) => (isClosing ? ANIMATION.FADE_OUT : ANIMATION.FADE_IN)};

--- a/src/presentation/components/common/Toast/List/style.ts
+++ b/src/presentation/components/common/Toast/List/style.ts
@@ -3,7 +3,10 @@ import styled from 'styled-components';
 export const StToastList = styled.div`
   bottom: 0;
   left: 0;
+  right: 0;
   position: fixed;
   z-index: 1000;
-  width: calc(100vw - 40px);
+  width: calc(100% - 40px);
+  max-width: 350px;
+  margin: 0 auto;
 `;

--- a/src/presentation/pages/Home/Neoga/index.tsx
+++ b/src/presentation/pages/Home/Neoga/index.tsx
@@ -18,15 +18,15 @@ function HomeNeoga() {
 
   useEffect(() => {
     (async () => {
-      const data = await api.neogaService.getMainTemplate();
-      setTemplateList(data);
+      const data = await api.neogaService.getBannerTemplate();
+      data && setBanner(data);
     })();
   }, []);
 
   useEffect(() => {
     (async () => {
-      const data = await api.neogaService.getBannerTemplate();
-      data && setBanner(data);
+      const data = await api.neogaService.getMainTemplate();
+      setTemplateList(data);
     })();
   }, []);
 


### PR DESCRIPTION
## ⛓ Related Issues
- close #177 

## 📋 작업 내용
- [x] 너가소개서 결과 페이지 에러 해결
- [x] 키워드가 있을 때만 '키워드모음' 텍스트 보이도록 수정
- [x] 너가소개서 결과 페이지 피그마랑 다른 부분 수정
- [x] 토스트 pc에서 이상하게 보이는 문제 해결

## 📌 PR Point
- 답변 피드가 0개일 때 생기는 에러를 해결했습니다. (neoga-result.ts의 getNeogaFeedbackResult 수정)
- 키워드가 없을 때도 키워드모음 텍스트가 보여서 이 부분도 같이 수정했습니다.
- 링크 복사하기 버튼 눌러봤는데 토스트가 pc 화면에서 넓게 보여서 같이 수정했습니다.

## 👀 스크린샷 / GIF / 링크
- 너가소개서 결과 페이지

|수정 전|수정 후|
|-|-|
|<img src="https://user-images.githubusercontent.com/58380158/153161069-4050bc42-0ca9-47ff-a97f-f281e9df3262.png" width="400px">|<img src="https://user-images.githubusercontent.com/58380158/153161169-10a50bc9-4efb-48d9-a4f6-529b3e43a7ac.png" width="400px">|

- 토스트

|수정 전|수정 후|
|-|-|
|<img src="https://user-images.githubusercontent.com/58380158/153160541-dec1c2b5-f6f2-4c7c-a0e6-2c1d98c5f606.png" width="400px">|<img src="https://user-images.githubusercontent.com/58380158/153160558-da957fad-0e1d-4396-ab85-fd089f816f6b.png" width="400px">|

