### PR TITLE
너소서 & 팀소서 메인 Can't perform a React state update on an unmounted component. 해결

### DIFF
--- a/src/infrastructure/api/types/team.ts
+++ b/src/infrastructure/api/types/team.ts
@@ -47,7 +47,7 @@ export type PostFeedbackBookmarkResponse = {
 };
 
 export type TeamIssueData = {
-  issueListData: TeamIssueCard[];
+  issueList: TeamIssueCard[];
 };
 
 export type TeamIssueCard = {
@@ -64,7 +64,7 @@ export type TeamIssueCard = {
 };
 
 export type TeamProfileData = {
-  profileListData: TeamMemberNoneId[];
+  profileList: TeamMemberNoneId[];
 };
 
 export type TeamDetail = {
@@ -88,7 +88,7 @@ export type TeamInvite = {
 };
 
 export type TeamInviteData = {
-  inviteListData: TeamInvite[];
+  inviteList: TeamInvite[];
 };
 
 export type TeamIssueCategory = {

--- a/src/infrastructure/mock/team.data.ts
+++ b/src/infrastructure/mock/team.data.ts
@@ -96,7 +96,7 @@ export const TEAM_DATA: {
     writer: '주영주영',
   },
   TEAM_ISSUE_INFO: {
-    issueListData: [
+    issueList: [
       {
         teamID: '1',
         issueNumber: 1,
@@ -159,7 +159,7 @@ export const TEAM_DATA: {
     ],
   },
   TEAM_PROFILE: {
-    profileListData: [
+    profileList: [
       {
         id: 6,
         profileImage: 'https://cdn.pixabay.com/photo/2021/07/13/11/34/cat-6463284_1280.jpg',
@@ -220,7 +220,7 @@ export const TEAM_DATA: {
     },
   },
   TEAM_INVITE_INFO: {
-    inviteListData: [
+    inviteList: [
       {
         id: 26,
         name: '너가소개서',

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -69,7 +69,7 @@ export function teamDataRemote(): TeamService {
     const response = await privateAPI.get({ url: `/team/detail/${teamID}/issue` });
     if (response.status === 200)
       return {
-        issueListData: response.data
+        issueList: response.data
           ? response.data.map((team: any) => ({
               issueNumber: team.id,
               issueMembers: team.feedback
@@ -97,7 +97,7 @@ export function teamDataRemote(): TeamService {
     const response = await privateAPI.get({ url: `/team/detail/${teamID}/issue/my` });
     if (response.status === 200)
       return {
-        issueListData: response.data
+        issueList: response.data
           ? response.data.map((team: any) => ({
               issueNumber: team.id,
               issueMembers: team.feedback
@@ -125,7 +125,7 @@ export function teamDataRemote(): TeamService {
     const response = await privateAPI.get({ url: `/team` });
     if (response.status === 200)
       return {
-        profileListData: response.data
+        profileList: response.data
           ? response.data.map((team: any) => ({
               id: team.id,
               profileImage: team.image,
@@ -161,7 +161,7 @@ export function teamDataRemote(): TeamService {
     const response = await privateAPI.get({ url: `/team/issue` });
     if (response.status === 200)
       return {
-        issueListData: response.data
+        issueList: response.data
           ? response.data.map((team: any) => ({
               teamID: team.teamId,
               issueCardImage: team.image ?? null,
@@ -187,7 +187,7 @@ export function teamDataRemote(): TeamService {
     const response = await privateAPI.get({ url: `/team/invite` });
     if (response.status === 200)
       return {
-        inviteListData: response.data
+        inviteList: response.data
           ? response.data.map((team: any) => ({
               id: team.id,
               name: team.name,

--- a/src/presentation/components/common/IssueCardList/index.tsx
+++ b/src/presentation/components/common/IssueCardList/index.tsx
@@ -15,15 +15,15 @@ export interface IssueListData {
 }
 
 interface IssueListProps {
-  issueListData: IssueListData[];
+  issueList: IssueListData[];
   onIssueClick: (teamID: string, issueNumber: number) => void;
 }
 
 function IssueCardList(props: IssueListProps) {
-  const { issueListData, onIssueClick } = props;
+  const { issueList, onIssueClick } = props;
   return (
     <div>
-      {issueListData.map((issue) => (
+      {issueList.map((issue) => (
         <IssueCard
           key={issue.teamID}
           onIssueClick={() => onIssueClick(issue.teamID, issue.issueNumber)}

--- a/src/presentation/components/common/ProfileList/index.tsx
+++ b/src/presentation/components/common/ProfileList/index.tsx
@@ -2,7 +2,7 @@ import ProfileItem from '@components/common/ProfileItem';
 import ProfileAddButton from '@components/common/ProfileAddButton';
 import { StProfileList, StItemWrapper } from './style';
 
-export interface ProfileListData {
+export interface ProfileList {
   id: number;
   profileImage?: string;
   profileName: string;
@@ -10,7 +10,7 @@ export interface ProfileListData {
 
 interface ProfileListProps {
   isSquare: boolean;
-  profileListData: ProfileListData[];
+  profileList: ProfileList[];
   onProfileClick?: (id: number) => void;
   onAddClick: () => void;
   isAddNeeded?: boolean;
@@ -19,7 +19,7 @@ interface ProfileListProps {
 function ProfileList(props: ProfileListProps) {
   const {
     isSquare,
-    profileListData,
+    profileList,
     onProfileClick = () => {
       return;
     },
@@ -30,7 +30,7 @@ function ProfileList(props: ProfileListProps) {
   return (
     <StProfileList>
       <StItemWrapper isSquare={isSquare}>
-        {profileListData.map(({ id, profileImage, profileName }) => (
+        {profileList.map(({ id, profileImage, profileName }) => (
           <ProfileItem
             key={id}
             id={id}

--- a/src/presentation/pages/Home/MyPage/index.tsx
+++ b/src/presentation/pages/Home/MyPage/index.tsx
@@ -152,7 +152,7 @@ function HomeMyPage() {
             </StTitle>
             <ProfileList
               isSquare={true}
-              profileListData={feedbackBookmark.teamList}
+              profileList={feedbackBookmark.teamList}
               onProfileClick={() => null}
               onAddClick={() => null}
               isAddNeeded={false}

--- a/src/presentation/pages/Home/Neoga/index.tsx
+++ b/src/presentation/pages/Home/Neoga/index.tsx
@@ -16,14 +16,15 @@ function HomeNeoga() {
   const initialState = {
     banner: null,
     templateList: [],
-    cardItem: undefined,
+    cardItem: null,
   };
 
   const [state, setState] = useState<{
-    banner?: NeogaBannerItem | null;
+    banner: NeogaBannerItem | null;
     templateList: NeogaMainCardItem[];
-    cardItem?: NeogaResultCardItem;
+    cardItem: NeogaResultCardItem | null;
   }>(initialState);
+
   const { banner, templateList, cardItem } = state;
 
   useEffect(() => {

--- a/src/presentation/pages/Home/Neoga/index.tsx
+++ b/src/presentation/pages/Home/Neoga/index.tsx
@@ -12,6 +12,7 @@ import { useLoginUser } from '@hooks/useLoginUser';
 function HomeNeoga() {
   const navigate = useNavigate();
   const { username } = useLoginUser();
+  const MAX_CARD_ITEM = 2;
 
   const initialState = {
     banner: null,
@@ -87,15 +88,15 @@ function HomeNeoga() {
             </button>
           )}
         </div>
-        {cardItem && cardItem?.resultList.length > 0 ? (
+        {cardItem && cardItem.resultList.length > 0 ? (
           <>
             {cardItem.resultList.map((result) => (
               <NeogaResultCard key={result.id} {...result} />
             ))}
-            {cardItem.count > 2 && (
+            {cardItem.count > MAX_CARD_ITEM && (
               <StButtonArea>
                 <button onClick={() => navigate('/neoga/result')}>
-                  외 {cardItem.count - 2}개 <span>더보기</span>
+                  외 {cardItem.count - MAX_CARD_ITEM}개 <span>더보기</span>
                 </button>
               </StButtonArea>
             )}

--- a/src/presentation/pages/Home/Neoga/index.tsx
+++ b/src/presentation/pages/Home/Neoga/index.tsx
@@ -1,43 +1,36 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '@api/index';
+import { NeogaMainCardItem, NeogaBannerItem, NeogaResultCardItem } from '@api/types/neoga';
+import { useLoginUser } from '@hooks/useLoginUser';
+import NeogaMainCardList from '@components/NeogaMainCard/List';
+import NeogaResultCard from '@components/common/NeogaResultCard';
 import { StBanner, StForm, StHomeNeoga, StResult, StButtonArea, StEmptyView } from './styles';
 import { icNewTag, icWhole } from '@assets/icons';
 import { imgEmptyMain } from '@assets/images';
-import { useNavigate } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import { api } from '@api/index';
-import { NeogaMainCardItem, NeogaBannerItem, NeogaResultCardItem } from '@api/types/neoga';
-import NeogaMainCardList from '@components/NeogaMainCard/List';
-import NeogaResultCard from '@components/common/NeogaResultCard';
-import { useLoginUser } from '@hooks/useLoginUser';
 
 function HomeNeoga() {
+  const [banner, setBanner] = useState<NeogaBannerItem>();
+  const [templateList, setTemplateList] = useState<NeogaMainCardItem[]>([]);
+  const [cardItem, setCardItem] = useState<NeogaResultCardItem>();
   const navigate = useNavigate();
   const { username } = useLoginUser();
   const MAX_CARD_ITEM = 2;
 
-  const initialState = {
-    banner: null,
-    templateList: [],
-    cardItem: null,
-  };
-
-  const [state, setState] = useState<{
-    banner: NeogaBannerItem | null;
-    templateList: NeogaMainCardItem[];
-    cardItem: NeogaResultCardItem | null;
-  }>(initialState);
-
-  const { banner, templateList, cardItem } = state;
-
   useEffect(() => {
     (async () => {
-      const data = await Promise.all([
-        api.neogaService.getBannerTemplate(),
-        api.neogaService.getMainTemplate(),
-        api.neogaService.getMainResultCard(),
-      ]);
-      setState({ banner: data[0], templateList: data[1], cardItem: data[2] });
+      const banner = await api.neogaService.getBannerTemplate();
+      banner && setBanner(banner);
+      const templateList = await api.neogaService.getMainTemplate();
+      setTemplateList(templateList);
+      const cardItem = await api.neogaService.getMainResultCard();
+      setCardItem(cardItem);
     })();
-    return () => setState(initialState);
+    return () => {
+      setBanner(undefined);
+      setTemplateList([]);
+      setCardItem(undefined);
+    }
   }, []);
 
   return (

--- a/src/presentation/pages/Home/Neoga/index.tsx
+++ b/src/presentation/pages/Home/Neoga/index.tsx
@@ -11,30 +11,31 @@ import { useLoginUser } from '@hooks/useLoginUser';
 
 function HomeNeoga() {
   const navigate = useNavigate();
-  const [banner, setBanner] = useState<NeogaBannerItem>();
-  const [templateList, setTemplateList] = useState<NeogaMainCardItem[]>([]);
-  const [cardItem, setCardItem] = useState<NeogaResultCardItem>();
   const { username } = useLoginUser();
 
-  useEffect(() => {
-    (async () => {
-      const data = await api.neogaService.getBannerTemplate();
-      data && setBanner(data);
-    })();
-  }, []);
+  const initialState = {
+    banner: null,
+    templateList: [],
+    cardItem: undefined,
+  };
+
+  const [state, setState] = useState<{
+    banner?: NeogaBannerItem | null;
+    templateList: NeogaMainCardItem[];
+    cardItem?: NeogaResultCardItem;
+  }>(initialState);
+  const { banner, templateList, cardItem } = state;
 
   useEffect(() => {
     (async () => {
-      const data = await api.neogaService.getMainTemplate();
-      setTemplateList(data);
+      const data = await Promise.all([
+        api.neogaService.getBannerTemplate(),
+        api.neogaService.getMainTemplate(),
+        api.neogaService.getMainResultCard(),
+      ]);
+      setState({ banner: data[0], templateList: data[1], cardItem: data[2] });
     })();
-  }, []);
-
-  useEffect(() => {
-    (async () => {
-      const data = await api.neogaService.getMainResultCard();
-      setCardItem(data);
-    })();
+    return () => setState(initialState);
   }, []);
 
   return (

--- a/src/presentation/pages/Home/Team/index.tsx
+++ b/src/presentation/pages/Home/Team/index.tsx
@@ -16,9 +16,6 @@ import {
 import { useResetRecoilState } from 'recoil';
 
 function HomeTeam() {
-  const [profileListData, setProfileListData] = useState<TeamMemberNoneId[] | null>(null);
-  const [issueListData, setIssueListData] = useState<TeamIssueCard[] | null>(null);
-  const [inviteData, setInviteData] = useState<TeamInvite[] | null>(null);
   const resetImage = useResetRecoilState(teamImageState);
   const resetName = useResetRecoilState(teamNameState);
   const resetDescription = useResetRecoilState(teamDescriptionState);
@@ -32,31 +29,35 @@ function HomeTeam() {
     resetSelectedUserList();
   };
 
-  useEffect(() => {
-    (async () => {
-      const { profileListData } = await api.teamService.getTeamProfile();
-      setProfileListData(profileListData);
-    })();
-  }, []);
+  const initialState = {
+    profileListData: null,
+    issueListData: null,
+    inviteListData: null,
+  };
+
+  const [state, setState] = useState<{
+    profileListData?: TeamMemberNoneId[] | null;
+    issueListData: TeamIssueCard[] | null;
+    inviteListData?: TeamInvite[] | null;
+  }>(initialState);
+  const { profileListData, issueListData, inviteListData } = state;
 
   useEffect(() => {
     (async () => {
-      const { issueListData } = await api.teamService.getMyTeamIssue();
-      setIssueListData(issueListData);
+      const data = await Promise.all([
+        api.teamService.getTeamProfile(),
+        api.teamService.getMyTeamIssue(),
+        api.teamService.getInviteInfo(),
+      ]);
+      setState({ profileListData: data[0].profileListData, issueListData: data[1].issueListData, inviteListData: data[2].inviteListData });
     })();
-  }, []);
-
-  useEffect(() => {
-    (async () => {
-      const { inviteListData } = await api.teamService.getInviteInfo();
-      setInviteData(inviteListData);
-    })();
+    return () => setState(initialState);
   }, []);
 
   return (
     <>
       <StTeamMain>
-        {inviteData?.map((invitation) => (
+        {inviteListData?.map((invitation) => (
           <TeamInvitation key={invitation.id} {...invitation} />
         ))}
         <h1>나와 함께하는 팀</h1>

--- a/src/presentation/pages/Home/Team/index.tsx
+++ b/src/presentation/pages/Home/Team/index.tsx
@@ -40,6 +40,7 @@ function HomeTeam() {
     issueListData: TeamIssueCard[] | null;
     inviteListData: TeamInvite[] | null;
   }>(initialState);
+  
   const { profileListData, issueListData, inviteListData } = state;
 
   useEffect(() => {

--- a/src/presentation/pages/Home/Team/index.tsx
+++ b/src/presentation/pages/Home/Team/index.tsx
@@ -36,9 +36,9 @@ function HomeTeam() {
   };
 
   const [state, setState] = useState<{
-    profileListData?: TeamMemberNoneId[] | null;
+    profileListData: TeamMemberNoneId[] | null;
     issueListData: TeamIssueCard[] | null;
-    inviteListData?: TeamInvite[] | null;
+    inviteListData: TeamInvite[] | null;
   }>(initialState);
   const { profileListData, issueListData, inviteListData } = state;
 

--- a/src/presentation/pages/Neoga/Link/Result/index.tsx
+++ b/src/presentation/pages/Neoga/Link/Result/index.tsx
@@ -32,8 +32,8 @@ export default function NeogaLinkResult() {
     <StNeogaLinkResult>
       {type === 'new' ? <ImgNewLink /> : <ImgCreatedLink />}
       <div>
-        <div>{type === 'new' ? '링크 생성 완료!' : '이미 생성된 링크예요!'}</div>
-        <div>해당 링크를 복사하여 공유해주세요</div>
+        <div>{type === 'new' ? '설문 링크 생성 완료!' : '이미 생성된 설문이에요'}</div>
+        <div>링크를 복사해서 친구들에게 공유해보세요</div>
       </div>
       <StLinkBox>
         <input type="text" value={link} disabled />

--- a/src/presentation/pages/NeososeoForm/Finish/index.tsx
+++ b/src/presentation/pages/NeososeoForm/Finish/index.tsx
@@ -11,9 +11,9 @@ function NeososeoFormFinish() {
       <StBody>
         <ImgAnswerDone />
         <div>답변이 전달되었어요</div>
-        <div>너가소개서, 좀 더 둘러보실래요?</div>
+        <div>내 너가소개서도 받아보세요.</div>
       </StBody>
-      <StButton onClick={() => navigate('/')}>서비스 둘러보기</StButton>
+      <StButton onClick={() => navigate('/')}>내 너가소개서도 받아보기</StButton>
     </StNeososeoFinish>
   );
 }

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -12,7 +12,7 @@ function TeamMain() {
   const [isMemberPopupOpened, setIsMemberPopupOpened] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
   const [teamInfoData, setTeamInfoData] = useState<TeamInfoData | undefined>(undefined);
-  const [issueListData, setIssueListData] = useState<TeamIssueCard[] | null>(null);
+  const [issueList, setIssueList] = useState<TeamIssueCard[] | null>(null);
   const { teamID } = useParams();
   const navigate = useNavigate();
   const checkMyIssue = () => setIsChecked((prev) => !prev);
@@ -24,8 +24,8 @@ function TeamMain() {
       if (teamID === undefined) return;
       const teamDetailData = await api.teamService.getTeamInfo(Number(teamID));
       setTeamInfoData(teamDetailData);
-      const { issueListData } = await api.teamService.getTeamIssue(teamID);
-      setIssueListData(issueListData);
+      const { issueList } = await api.teamService.getTeamIssue(teamID);
+      setIssueList(issueList);
     })();
   }, []);
 
@@ -33,13 +33,13 @@ function TeamMain() {
     if (teamID === undefined) return;
     if (!isChecked) {
       (async () => {
-        const { issueListData } = await api.teamService.getTeamIssue(teamID);
-        setIssueListData(issueListData);
+        const { issueList } = await api.teamService.getTeamIssue(teamID);
+        setIssueList(issueList);
       })();
     } else {
       (async () => {
-        const { issueListData } = await api.teamService.getMyIssue(teamID);
-        setIssueListData(issueListData);
+        const { issueList } = await api.teamService.getMyIssue(teamID);
+        setIssueList(issueList);
       })();
     }
   }, [isChecked]);
@@ -84,9 +84,9 @@ function TeamMain() {
         </button>
         내가 언급된 이슈만 보기
       </StCheckWrapper>
-      {issueListData && (
+      {issueList && (
         <IssueCardList
-          issueListData={issueListData}
+          issueList={issueList}
           onIssueClick={(teamID, issueNumber) => {
             navigate(`/team/${teamID}/${issueNumber}`);
           }}

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -24,12 +24,6 @@ function TeamMain() {
       if (teamID === undefined) return;
       const teamDetailData = await api.teamService.getTeamInfo(Number(teamID));
       setTeamInfoData(teamDetailData);
-    })();
-  }, []);
-
-  useEffect(() => {
-    (async () => {
-      if (teamID === undefined) return;
       const { issueListData } = await api.teamService.getTeamIssue(teamID);
       setIssueListData(issueListData);
     })();

--- a/src/presentation/pages/Team/Register/index.tsx
+++ b/src/presentation/pages/Team/Register/index.tsx
@@ -77,7 +77,7 @@ function TeamRegister() {
       <CommonLabel content="팀원을 추가해주세요" marginTop="44px" marginBottom="18px" />
       <ProfileList
         isSquare={false}
-        profileListData={[
+        profileList={[
           { id: id, profileName: username, profileImage: profileImage ?? imgEmptyProfile },
           ...selectedUserList,
         ]}


### PR DESCRIPTION
## ⛓ Related Issues
- #127 

## 📋 작업 내용
- [x] `Can't perform a React state update on an unmounted component.` 콘솔에 찍히는 문제 해결
- [x] 너가소개서, 팀원소개서 메인 페이지 렌더링 횟수 줄어들도록 리팩토링

## 📌 PR Point
- useEffect의 cleanup 함수를 이용해 문제를 해결했습니다.
주요 변경사항은 다음과 같습니다.
  ```typescript
  // useState에서 사용할 기본값이자 cleanup 함수에서 사용할 initialState 정의
  const initialState = {
      banner: null,
      templateList: [],
      cardItem: null,
  };

  // const [banner, setBanner] = useState<NeogaBannerItem>(); 
  // const [templateList, setTemplateList] = useState<NeogaMainCardItem[]>([]);
  // const [cardItem, setCardItem] = useState<NeogaResultCardItem>();
  // 이런 식으로 따로 작성했던 것들 아래처럼 하나의 state로 수정
  const [state, setState] = useState<{
    banner: NeogaBannerItem | null;
    templateList: NeogaMainCardItem[];
    cardItem: NeogaResultCardItem | null;
  }>(initialState);

  // 구조 분해 할당
  const { banner, templateList, cardItem } = state;
  
  useEffect(() => {
    (async () => {
      const data = await Promise.all([
        api.neogaService.getBannerTemplate(),
        api.neogaService.getMainTemplate(),
        api.neogaService.getMainResultCard(),
      ]);
      setState({ banner: data[0], templateList: data[1], cardItem: data[2] });
    })();
    // cleanup 함수를 이용해서 initialState(banner는 null, templateList는 [], cardItem은 null)로 만든다.
    return () => setState(initialState);
  }, []);
  ```
- 여러 개의 요청을 보내고, 요청에 대한 응답이 모두 왔을 때 한 번에 화면을 렌더링 하기 위해 `Promise.all`을 사용했습니다. 
중단점을 찍어보니 렌더링 횟수가 줄어든 것을 확인할 수 있었습니다.

## 🔬 Reference
- 오류에 대한 설명은 아래 링크에서 확인할 수 있습니다.
https://kyounghwan01.github.io/blog/React/cant-perform-a-React-state-update-on-an-unmounted-component/#%E1%84%87%E1%85%A1%E1%86%AF%E1%84%89%E1%85%A2%E1%86%BC-%E1%84%8B%E1%85%B5%E1%84%8B%E1%85%B2
