### PR TITLE
랜딩 페이지 버그 없애기

### DIFF
--- a/src/presentation/components/LandingPage/index.tsx
+++ b/src/presentation/components/LandingPage/index.tsx
@@ -30,7 +30,7 @@ function LandingPage() {
   return (
     <div>
       <StHeader>
-        <img src={imgLogo}></img>
+        <img src={imgLogo} />
         <StLogin
           onClick={() => {
             navigate(`/login`);
@@ -57,7 +57,7 @@ function LandingPage() {
           너가소개서 받으러 가기
         </StServiceButton>
       </StMain>
-      <StMiddle style={{ position: 'relative' }}>
+      <StMiddle>
         <StMiddleTitle>
           <h2>
             나를 알아갈 수 있는

--- a/src/presentation/pages/Landing/index.tsx
+++ b/src/presentation/pages/Landing/index.tsx
@@ -1,11 +1,14 @@
 import LandingPage from '@components/LandingPage';
 import { useLoginUser } from '@hooks/useLoginUser';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 
 function Landing() {
   const { isAuthenticated } = useLoginUser();
   const navigate = useNavigate();
-  if (isAuthenticated) navigate('/home');
+  useEffect(()=> {
+    if (isAuthenticated) navigate('/home');
+  }, [isAuthenticated]);
   return <LandingPage />;
 }
 


### PR DESCRIPTION
## ⛓ Related Issues
- close #185 

## 📋 작업 내용
- [x] 아래 warning 제거
![image](https://user-images.githubusercontent.com/58380158/153544666-58a4377b-5be8-4581-b371-baed831d73c4.png)

## 📌 PR Point
- warning을 제거하기 위해 useEffect를 사용해 코드를 수정했습니다.
- `<StMiddle style={{ position: 'relative' }}>`처럼 적용되어 있었는데, 인라인 스타일은 지양하는 것이 좋을 것 같습니다. StMiddle로 인라인 스타일을 옮기려고 했는데 `position: relative`가 없어도 똑같아서 제거했습니다.

## 🔬 Reference
- 구현에 참고한 링크
https://stackoverflow.com/questions/62336340/cannot-update-a-component-while-rendering-a-different-component-warning
