### PR TITLE
너소서 생성 첫화면 / 답변 첫화면 일그러진 UI 수정

### DIFF
--- a/src/application/utils/string.ts
+++ b/src/application/utils/string.ts
@@ -1,2 +1,13 @@
 export const isAllFilled = (...args: unknown[]) =>
   args.every((arg) => arg !== null && arg !== undefined && arg !== '');
+
+export const splitIntoTwoLines = (oneLineString: string): string => {
+  const splittedString = oneLineString.split(' ');
+  let firstLine = '',
+    secondLine = '';
+  while (splittedString.length) {
+    if (firstLine.length < secondLine.length) firstLine += ' ' + splittedString.shift();
+    else secondLine = splittedString.pop() + ' ' + secondLine;
+  }
+  return firstLine + '\n' + secondLine;
+};

--- a/src/presentation/components/common/NeososeoFormHeader/index.tsx
+++ b/src/presentation/components/common/NeososeoFormHeader/index.tsx
@@ -1,3 +1,4 @@
+import { splitIntoTwoLines } from '@utils/string';
 import { StNeososeoFormHeader } from './style';
 
 interface NeososeoFormHeaderProps {
@@ -9,7 +10,7 @@ function NeososeoFormHeader(props: NeososeoFormHeaderProps) {
   const { title, image } = props;
   return (
     <StNeososeoFormHeader>
-      <div>{title}</div>
+      <div>{splitIntoTwoLines(title)}</div>
       <div>
         <img src={image} alt={title} />
       </div>

--- a/src/presentation/components/common/Question/index.tsx
+++ b/src/presentation/components/common/Question/index.tsx
@@ -1,5 +1,6 @@
 import { StQuestion, StContent, StFlexWrapper } from './style';
 import { ImgQuestionFrame } from '@assets/images';
+import { splitIntoTwoLines } from '@utils/string';
 
 export default function Question({ content }: { content: string }) {
   return (
@@ -8,7 +9,7 @@ export default function Question({ content }: { content: string }) {
         <ImgQuestionFrame />
         <StContent>
           <div>Q.</div>
-          <div>{content}</div>
+          <div>{splitIntoTwoLines(content)}</div>
         </StContent>
       </StFlexWrapper>
     </StQuestion>

--- a/src/presentation/components/common/Question/style.ts
+++ b/src/presentation/components/common/Question/style.ts
@@ -12,8 +12,10 @@ export const StQuestion = styled.div`
 
 export const StFlexWrapper = styled.div`
   position: relative;
+  height: min(400px, 100vw);
   & svg {
     width: 100%;
+    height: min(400px, 100vw);
   }
 `;
 
@@ -41,7 +43,6 @@ export const StContent = styled.div`
     ${FONT_STYLES.M_16_BODY}
     line-height: 143.99%;
     letter-spacing: -0.01em;
-    padding-right: 24px;
     word-break: keep-all;
   }
 `;


### PR DESCRIPTION
## ⛓ Related Issues
- close #187 

## 📋 작업 내용
- [x] 스트링을 두 줄로 쪼개는 유틸 추가
- [x] 너소서 생성 화면 / 너소서 폼 작성 화면의 첫 페이지에 있는 그 카드 (이름이 Question이더라,,)의 스타일 수정

## 📌 PR Point
- splitIntoTwoLines 친구의 기능을 확인해주시고, 쓰여야 할 때 많이 써주시면 좋겠습니다!!

## 👀 스크린샷 / GIF / 링크

<div align="center">
<img height="420" alt="image" src="https://user-images.githubusercontent.com/48249505/153554512-201d22a3-02ea-4958-b2c8-09bebe6732c8.png">
<img height="420"  alt="image" src="https://user-images.githubusercontent.com/48249505/153554550-0c440d41-471f-4c9c-998e-6974f4993267.png">
</div>


## 🔬 Reference
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)
