### PR TITLE
console.log 숙청 및 e, err을 모두 error로 통합

### DIFF
--- a/src/infrastructure/api/login-user.ts
+++ b/src/infrastructure/api/login-user.ts
@@ -15,8 +15,8 @@ export const postLogin = async (
     });
     if (response.status === 200) return response.data;
     else throw '로그인 실패';
-  } catch (e) {
-    console.error(e);
+  } catch (error) {
+    console.error(error);
     throw '로그인 실패';
   }
 };

--- a/src/infrastructure/mock/neoga.ts
+++ b/src/infrastructure/mock/neoga.ts
@@ -42,8 +42,7 @@ export function neogaDataMock(): NeogaService {
     return { isSuccess: true };
   };
 
-  const postCreateForm = async (formID: number) => {
-    console.log(formID);
+  const postCreateForm = async () => {
     await wait(2000);
     return { isCreated: true, q: '큐' };
   };

--- a/src/infrastructure/mock/neososeo-form.ts
+++ b/src/infrastructure/mock/neososeo-form.ts
@@ -1,5 +1,4 @@
 import { NeososeoFormService } from '@api/neososeo-form';
-import { NeososeoAnswerData } from '@api/types/neososeo-form';
 import { NEOSOSEO_FORM_DATA } from './neososeo-form.data';
 
 export function NeososeoFormMock(): NeososeoFormService {
@@ -8,8 +7,7 @@ export function NeososeoFormMock(): NeososeoFormService {
     return NEOSOSEO_FORM_DATA.FORM;
   };
 
-  const postFormAnswer = async (body: NeososeoAnswerData) => {
-    console.log(body);
+  const postFormAnswer = async () => {
     await wait(2000);
     return { isSuccess: true };
   };

--- a/src/infrastructure/remote/issue.ts
+++ b/src/infrastructure/remote/issue.ts
@@ -17,7 +17,7 @@ export const postTeamIssue = async (issueData: FormData) => {
         type: 'multipart',
       })
       .catch((error) => {
-        console.log(error.response);
+        console.error(error.response);
       });
     if (response.status === 200) {
       return response;

--- a/src/infrastructure/remote/neoga.ts
+++ b/src/infrastructure/remote/neoga.ts
@@ -150,7 +150,7 @@ export function NeogaDataRemote(): NeogaService {
         data: { formId: formID },
       })
       .catch((e: AxiosError) => {
-        console.log(e.response);
+        console.error(e.response);
       });
     return { isCreated: response.message === '이미 존재하는 폼입니다', q: response.data };
   };

--- a/src/infrastructure/remote/neoga.ts
+++ b/src/infrastructure/remote/neoga.ts
@@ -149,8 +149,8 @@ export function NeogaDataRemote(): NeogaService {
         url: `/form/create`,
         data: { formId: formID },
       })
-      .catch((e: AxiosError) => {
-        console.error(e.response);
+      .catch((error: AxiosError) => {
+        console.error(error.response);
       });
     return { isCreated: response.message === '이미 존재하는 폼입니다', q: response.data };
   };

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -219,7 +219,7 @@ export function teamDataRemote(): TeamService {
           type: 'multipart',
         })
         .catch((e: AxiosError) => {
-          console.log(e.response);
+          console.error(e.response);
         });
       if (response.status === 200) {
         return { isSuccess: true };

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -218,8 +218,8 @@ export function teamDataRemote(): TeamService {
           data: teamInfo,
           type: 'multipart',
         })
-        .catch((e: AxiosError) => {
-          console.error(e.response);
+        .catch((error: AxiosError) => {
+          console.error(error.response);
         });
       if (response.status === 200) {
         return { isSuccess: true };

--- a/src/presentation/components/JoinForm/index.tsx
+++ b/src/presentation/components/JoinForm/index.tsx
@@ -73,7 +73,8 @@ function JoinForm() {
         fireToast({ content: '중복된 아이디입니다. ' });
       }
     } catch (error) {
-      console.error(error); //나중에 또 처리합시다.
+      console.error(error);
+      navigate('/');
     }
   };
 

--- a/src/presentation/pages/Team/Issue/NewIssue/index.tsx
+++ b/src/presentation/pages/Team/Issue/NewIssue/index.tsx
@@ -72,7 +72,7 @@ function TeamNewIssue() {
         navigate(`/team/${teamID}`);
       }
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
   };
 


### PR DESCRIPTION
## ⛓ Related Issues
- close #189 

## 📋 작업 내용
- [x] console.log 숙청. 디버깅 때 편할 것 같은 친구들은 console.error로 바꿈!!
- [x] e, err이라는 변수명을 모두 error으로 바꿈..

## 📌 PR Point
- 젼언니가 is defined but not used때문에 console.log를 지울 수 없었다고 했는데, 사실 맘껏 지워도 되는 친구였어~!

API 인터페이스가 정의될 때 
`@api/neoga.ts`
```ts
interface NeogaService {
  ...
  postCreateForm(formID: number): Promise<{ isCreated: boolean; q: string }>;
  ...
}
```
이렇게 postCreateForm은 formID를 매개변수로 받아야 하는 함수이지만,
매개변수로 아무것도 안 받는 함수도 저 친구의 타입을 덮어쓸 수 있어!! 그래서
`@infrastructure/remote/mock.ts`
```ts
  const postCreateForm = async () => {
    await wait(2000);
    return { isCreated: true, q: '큐' };
  };
```
이런 식으로 매개변수를 지워버려도 에러가 안 난다!!
따라서 다음부턴 맘껏 지워주어도 돼~
