### PR TITLE
피드백 생성 이후 뒤로가기 스택에 쌓이는 오류 해결, 첫 피드백이 안 뜨는 오류 해결

### DIFF
--- a/src/presentation/components/common/IssueCardList/index.tsx
+++ b/src/presentation/components/common/IssueCardList/index.tsx
@@ -25,7 +25,7 @@ function IssueCardList(props: IssueListProps) {
     <div>
       {issueList.map((issue) => (
         <IssueCard
-          key={issue.teamID}
+          key={issue.issueNumber}
           onIssueClick={() => onIssueClick(issue.teamID, issue.issueNumber)}
           {...issue}
         />

--- a/src/presentation/pages/Team/Issue/Feedback/index.tsx
+++ b/src/presentation/pages/Team/Issue/Feedback/index.tsx
@@ -64,7 +64,7 @@ function TeamIssueFeedback() {
           isBookmarked: false,
         },
       ]);
-      navigate('../');
+      navigate(-1);
     }
   };
 

--- a/src/presentation/pages/Team/Issue/index.tsx
+++ b/src/presentation/pages/Team/Issue/index.tsx
@@ -66,7 +66,7 @@ function TeamIssue() {
             <StIssueThumbnail src={issue.team.thumbnail} alt={issue.title} />
           )}
           <StDivisionLine />
-          {issue.feedbackList.length !== 0 ? (
+          {feedbacks.length !== 0 ? (
             <FeedbackCardList feedbacks={feedbacks} />
           ) : (
             <FeedbackEmptyView hasThumbnail={issue.team.thumbnail !== null} />


### PR DESCRIPTION
## ⛓ Related Issues
- close #196 
- close #195 

## 📋 작업 내용
- [x] 피드백 생성 이후 뒤로가기 스택에 쌓이는 오류 해결
- [x] 피드백이 없던 이슈에 피드백을 작성했을 때 한 번에 안 뜨는 오류 해결
- [x] 이슈 카드 리스트에서 key가 중복되어서 생기는 워닝 해결

## 📌 PR Point
- 진짜 파일 당 한 줄 씩만 바꿨습니다..
- 이번 이슈에서 리액트 쿼리를 대거 도입하려 했는데 도입 없이 해결할 수 있는 문제라 안했습니다!
- 모바일에선 아예 스택의 탑 값을 비워버려서 앞으로 가기 버튼이 없는데 웹은 앞으로 가기 버튼도 있어서 내가 완벽하게 꼼꼼하게 처리하지는 못한 듯!!

### 리액트 쿼리를 도입한다면?

지금 피드백의 경우, 작성 이후에 새로고침 없이 바로 뜨게 되어 있어요
```tsx
  const setFeedbacks = useSetRecoilState(teamFeedbackState);
 
  ...

  const onPostFeedback = async () => {
    ...
    const response = await api.teamService.postFeedback({
      issueId: +issueID,
      taggedUserId: selectedUser.id,
      content,
      keywordIds: keywordList.map((keyword) => +keyword.id),
    });
    if (response.isSuccess) {
      setFeedbacks((prev) => [
        ...prev,
        {
          id: response.createdFeedbackID.toString(),
          writer: username.toString(),
          target: selectedUser.profileName.toString(),
          targetProfileID: '',
          body: content.toString(),
          createdAt: response.createdAt.toString(),
          keywordList: [...keywordList],
          isBookmarked: false,
        },
      ]);
      navigate(-1);
    }
  };
```

if문 다음 로직이 중요한데요!
레코일 상태에 존재하는 피드백 리스트를 setFeedbacks()함수로 갱신해줍니다!!
많이 써보신 형태의 로직일텐데 그냥 이전 리스트의 맨 뒤에 새 데이터를 넣어주는 함수에요

이런 코드가 useMutation() 등의 훅을 쓰면 좀 더 간결해지고 편해질 것 같아요!
내일 회의 전까지 제일 만만한 부분에 도입해보겠습니둥!!