### PR TITLE
서버 response 바뀌는 부분 똑같이 수정

### DIFF
--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -70,23 +70,23 @@ export function teamDataRemote(): TeamService {
     if (response.status === 200)
       return {
         issueList: response.data
-          ? response.data.map((team: any) => ({
-              issueNumber: team.id,
-              issueMembers: team.feedback
-                ? team.feedback.map((member: any) => ({
-                    id: member.userId,
+          ? response.data.map((issue: any) => ({
+              issueNumber: issue.id,
+              issueCardImage: issue.image ?? null,
+              category: issue.categoryName,
+              dates: issue.createdAt,
+              content: issue.content,
+              issueMembers: issue.feedback
+                ? issue.feedback.map((member: any) => ({
+                    id: member.id,
                     profileName: member.name,
                     profileImage: member.image,
                   }))
                 : [],
-              category: team.categoryName,
-              dates: team.createdAt,
-              content: team.content,
-              teamID: team.teamId,
-              issueCardImage: team.image ?? null,
-              teamName: team.teamName,
-              teamImage: team.teamImage,
-              memberName: team.userName,
+              teamID: issue.team.id,
+              teamName: issue.team.name,
+              teamImage: issue.team.image,
+              memberName: issue.team.userName,
             }))
           : [],
       };
@@ -98,23 +98,23 @@ export function teamDataRemote(): TeamService {
     if (response.status === 200)
       return {
         issueList: response.data
-          ? response.data.map((team: any) => ({
-              issueNumber: team.id,
-              issueMembers: team.feedback
-                ? team.feedback.map((member: any) => ({
-                    id: member.userId,
+          ? response.data.map((issue: any) => ({
+              issueNumber: issue.id,
+              issueCardImage: issue.image ?? null,
+              category: issue.categoryName,
+              dates: issue.createdAt,
+              content: issue.content,
+              issueMembers: issue.feedback
+                ? issue.feedback.map((member: any) => ({
+                    id: member.id,
                     profileName: member.name,
                     profileImage: member.image,
                   }))
                 : [],
-              category: team.categoryName,
-              dates: team.createdAt,
-              content: team.content,
-              teamID: team.teamId,
-              issueCardImage: team.image ?? null,
-              teamName: team.teamName,
-              teamImage: team.teamImage,
-              memberName: team.userName,
+              teamID: issue.team.id,
+              teamName: issue.team.name,
+              teamImage: issue.team.image,
+              memberName: issue.team.userName,
             }))
           : [],
       };
@@ -161,21 +161,21 @@ export function teamDataRemote(): TeamService {
     if (response.status === 200)
       return {
         issueList: response.data
-          ? response.data.map((team: any) => ({
-              teamID: team.teamId,
-              issueCardImage: team.image ?? null,
-              issueNumber: team.id,
-              issueMembers: team.feedback.map((member: any) => ({
-                id: member.userId,
+          ? response.data.map((issue: any) => ({
+              issueNumber: issue.id,
+              issueCardImage: issue.image ?? null,
+              category: issue.categoryName,
+              dates: issue.createdAt,
+              content: issue.content,
+              issueMembers: issue.feedback.map((member: any) => ({
+                id: member.id,
                 profileName: member.name,
                 profileImage: member.image,
               })),
-              category: team.categoryName,
-              dates: team.createdAt,
-              content: team.content,
-              teamName: team.teamName,
-              teamImage: team.teamImage,
-              memberName: team.userName,
+              teamID: issue.team.id,
+              teamName: issue.team.name,
+              teamImage: issue.team.image,
+              memberName: issue.team.userName,
             }))
           : [],
       };


### PR DESCRIPTION
## ⛓ Related Issues
- close #205 

## 📋 작업 내용
- [x] 팀원소개서 관련 response가 바뀔 예정이라 같은 형태로 수정했습니다.
- [x] team/issue
- [x] team/detail/:teamId/issue
- [x] team/detail/:teamId/issue/my

## 📌 PR Point
- 아직 서버 머지/배포 안 했고, 지금 올리는 PR 리뷰 끝나면 같이 머지하려고 합니다!
- member.userId ➡️ member.id로 수정했습니다.
- team 관련 response 바뀐 부분은 아래와 같습니다.
teamID: team.teamId, ➡️ teamID: issue.team.id,
teamName: team.teamName, ➡️ teamName: issue.team.name,
teamImage: team.teamImage, ➡️ teamImage: issue.team.image,
memberName: team.userName, ➡️ memberName: issue.team.userName,

  [Before]
  ```
  "teamId": 1,
  "teamName": "SOPT",
  "teamImage": "https://firebasestorage.googleapis.com/v0/b/neogasogaeseo-9aaf5.appspot.com/o/29_SOPT_WEB_1-scaled.jpg?alt=media",
  "userName": "주미"
  ```
  
  [After]
  ```
  "team": {
      "id": 30,
      "name": "zz",
      "image": null,
      "userName": "서진맥북"
  }
  ```