### PR TITLE
너소서 폼 작성 정보 조회 서버 리스폰스 수정 및 뷰에 반영

### DIFF
--- a/src/infrastructure/api/types/neososeo-form.ts
+++ b/src/infrastructure/api/types/neososeo-form.ts
@@ -10,7 +10,9 @@ export type NeososeoFormData = {
   relation: Relation[];
   userName: string;
   userID: number;
+  userProfileImage?: string;
   formID: number;
+  answerCount: number;
 };
 
 export type NeososeoAnswerData = {

--- a/src/infrastructure/mock/neososeo-form.data.ts
+++ b/src/infrastructure/mock/neososeo-form.data.ts
@@ -15,5 +15,7 @@ export const NEOSOSEO_FORM_DATA: { FORM: NeososeoFormData } = {
     userName: '강쥐',
     userID: 1,
     formID: 1,
+    userProfileImage: '',
+    answerCount: 0,
   },
 };

--- a/src/infrastructure/remote/neososeo-form.ts
+++ b/src/infrastructure/remote/neososeo-form.ts
@@ -17,6 +17,8 @@ export function NeososeoFormRemote(): NeososeoFormService {
       userName: response.data.user.name,
       userID: response.data.user.id,
       formID: response.data.form.linkFormId,
+      userProfileImage: response.data.user.image,
+      answerCount: response.data.answerCount,
     };
   };
 

--- a/src/presentation/components/common/Header/index.tsx
+++ b/src/presentation/components/common/Header/index.tsx
@@ -7,7 +7,12 @@ import { useLoginUser } from '@hooks/useLoginUser';
 import { api } from '@api/index';
 import { useQuery } from 'react-query';
 
-export default function CommonHeader() {
+type CommonHeaderProps = {
+  isLogoOnly?: boolean;
+};
+
+export default function CommonHeader(props: CommonHeaderProps) {
+  const { isLogoOnly = false } = props;
   const navigate = useNavigate();
   const { isAuthenticated } = useLoginUser();
   const { data: isNotice } = useQuery('isNotice', () => api.headerService.getIsNotice());
@@ -19,23 +24,24 @@ export default function CommonHeader() {
             navigate('/home');
           }}
         />
-        {isAuthenticated ? (
-          <>
-            <StWrapper>
-              <IcSetting />
-              <IcBell onClick={() => navigate('/team/alert')} />
-            </StWrapper>
-            {isNotice && <StNotification />}
-          </>
-        ) : (
-          <StLoginButton
-            onClick={() => {
-              navigate(`/login`);
-            }}
-          >
-            로그인
-          </StLoginButton>
-        )}
+        {!isLogoOnly &&
+          (isAuthenticated ? (
+            <>
+              <StWrapper>
+                <IcSetting />
+                <IcBell onClick={() => navigate('/team/alert')} />
+              </StWrapper>
+              {isNotice && <StNotification />}
+            </>
+          ) : (
+            <StLoginButton
+              onClick={() => {
+                navigate(`/login`);
+              }}
+            >
+              로그인
+            </StLoginButton>
+          ))}
       </div>
     </StCommonHeader>
   );

--- a/src/presentation/pages/NeososeoForm/Home/index.tsx
+++ b/src/presentation/pages/NeososeoForm/Home/index.tsx
@@ -4,6 +4,7 @@ import FormCard from '@components/common/FormCard';
 import { useNavigate, useOutletContext } from 'react-router-dom';
 import { StButton } from '../style';
 import { StNeososeoFormHome, StAnswerCount } from './style';
+import { imgEmptyProfile } from '@assets/images';
 
 interface OutletContextProps {
   neososeoFormData: NeososeoFormData;
@@ -15,9 +16,12 @@ function NeososeoFormHome() {
 
   return (
     <StNeososeoFormHome>
-      <CommonHeader />
+      <CommonHeader isLogoOnly />
       <div>
-        <img src="https://github.com/seojinseojin.png" alt={neososeoFormData.userName} />
+        <img
+          src={neososeoFormData.userProfileImage ?? imgEmptyProfile}
+          alt={neososeoFormData.userName}
+        />
         <div>
           <div>{neososeoFormData.userName}님의 너가소개서</div>
           <div>2022-03-02</div>
@@ -29,7 +33,7 @@ function NeososeoFormHome() {
           title={neososeoFormData.title}
           content={neososeoFormData.content}
         >
-          <StAnswerCount>{3}명이 답변했어요</StAnswerCount>
+          <StAnswerCount>{neososeoFormData.answerCount}명이 답변했어요</StAnswerCount>
         </FormCard>
       </div>
       <div>


### PR DESCRIPTION
## ⛓ Related Issues
- close #284

## 📋 작업 내용
- [x] 너소서 폼 작성 정보 조회 서버 리스폰스 수정, 뷰에 반영
- [x] CommonHeader에 로고만 있는 버전 추가

## 📌 PR Point
- CommonHeader에 로고만 있는 버전을 만들기 위하여 prop을 하나 더 추가하였습니다
```ts
type CommonHeaderProps = {
  isLogoOnly?: boolean;
};
```

```ts
<CommonHeader isLogoOnly />
```
이렇게 주면 로고만 보입니다!