### PR TITLE
알림 조회 페이지에 pagination, mutation 적용하기

### DIFF
--- a/src/application/utils/constant.ts
+++ b/src/application/utils/constant.ts
@@ -1,6 +1,7 @@
 export const isProduction = process.env.NODE_ENV === 'production';
 export const DOMAIN = isProduction ? 'https://neogasogaeseo.com' : 'http://localhost:3000';
 export const KEYWORD_PAGE = 15;
+export const NOTICE_PAGE = 15;
 export const SCROLL_BOTTOM_PADDING = 30;
 export const MAX_TEAM_MEMBER = 4;
 export const STATUS_CODE = {

--- a/src/infrastructure/api/team.ts
+++ b/src/infrastructure/api/team.ts
@@ -42,7 +42,7 @@ export interface TeamService {
   rejectInvitation(teamID: number): Promise<{ isSuccess: boolean }>;
   editTeamInfo(teamInfo: TeamEditInfo<ImageFile>): Promise<{ isSuccess: boolean }>;
   deleteTeam(teamID: number): Promise<{ isSuccess: boolean }>;
-  getNotice(): Promise<TeamNoticeItem[]>;
+  getNotice(page: number): Promise<TeamNoticeItem[]>;
   getTeamEditMember(teamID: number): Promise<TeamEditMember[]>;
   deleteFeedback(feedbackID: number): Promise<{ isSuccess: boolean }>;
   deleteIssue(issueID: number): Promise<{ isSuccess: boolean }>;

--- a/src/infrastructure/api/types/team.ts
+++ b/src/infrastructure/api/types/team.ts
@@ -141,9 +141,15 @@ export type TeamNoticeItem = {
   teamID: number;
   teamName: string;
   teamProfileImage: string | undefined;
-  status: 'PENDING' | 'ACCEPT' | 'DECLINE';
+  status: TeamNoticeStatus;
   timeDifference: string;
 };
+
+export enum TeamNoticeStatus {
+  PENDING = 'PENDING',
+  ACCEPT = 'ACCEPT',
+  DECLINE = 'DECLINE',
+}
 
 export type TeamEditMember = {
   id: number;
@@ -151,4 +157,14 @@ export type TeamEditMember = {
   profileID: string;
   image: string | null;
   isConfirmed: boolean;
+};
+
+export type TeamNoticePaginateItems = {
+  pages:
+    | {
+        result: TeamNoticeItem[];
+        nextPage?: number | undefined;
+        isLast: boolean;
+      }[]
+    | undefined;
 };

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -3,7 +3,7 @@ import { AxiosError } from 'axios';
 import { ForbiddenError } from '@api/types/errors';
 import { ImageFile, PostFeedbackRequestBody, TeamEditInfo } from '@api/types/team';
 import { TeamService } from '@api/team';
-import { SEARCHED_USER_PAGE, STATUS_CODE } from '@utils/constant';
+import { NOTICE_PAGE, SEARCHED_USER_PAGE, STATUS_CODE } from '@utils/constant';
 import { getTimeDifference } from '@utils/date';
 import { privateAPI } from './base';
 
@@ -323,8 +323,10 @@ export function teamDataRemote(): TeamService {
     return { isSuccess: response.success };
   };
 
-  const getNotice = async () => {
-    const response = await privateAPI.get({ url: '/user/notice?offset=0&limit=40' });
+  const getNotice = async (page: number) => {
+    const response = await privateAPI.get({
+      url: `/user/notice?offset=${page}&limit=${NOTICE_PAGE}`,
+    });
     return response.data.notice.map((notice: any) => {
       const invitationUpdatedTime = new Date(notice.invitation.updatedAt);
       const now = new Date(Date.now());

--- a/src/presentation/pages/Team/Alert/index.tsx
+++ b/src/presentation/pages/Team/Alert/index.tsx
@@ -1,18 +1,49 @@
 import { api } from '@api/index';
+import CommonLoader from '@components/common/Loader';
 import CommonNavigation from '@components/common/Navigation';
 import TeamNoticeItem from '@components/TeamNoticeItem';
-import { useQuery } from 'react-query';
+import { useScrollHeight } from '@hooks/useScrollHeight';
+import { NOTICE_PAGE } from '@utils/constant';
+import { useEffect } from 'react';
+import { useCallback } from 'react';
+import { useInfiniteQuery } from 'react-query';
 import { StTeamNoticeItemContainer } from './style';
 
 function TeamAlert() {
-  const { data: noticeList } = useQuery(['notice'], () => api.teamService.getNotice());
+  const { isBottomReached, isInitialState } = useScrollHeight();
+
+  const fetchNoticeByPage = useCallback(async ({ pageParam = 0 }) => {
+    const response = await api.teamService.getNotice(pageParam);
+    return {
+      result: response,
+      nextPage: pageParam + NOTICE_PAGE,
+      isLast: response.length < NOTICE_PAGE,
+      id: pageParam,
+    };
+  }, []);
+  const {
+    data: noticeList,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery('notice', fetchNoticeByPage, {
+    getNextPageParam: (lastPage) => (lastPage.isLast ? undefined : lastPage.nextPage),
+  });
+
+  useEffect(() => {
+    if (!isInitialState) fetchNextPage();
+  }, [isBottomReached, isInitialState]);
+
   return (
     <>
       <CommonNavigation isBack={true} title="알림" />
       <StTeamNoticeItemContainer>
-        {noticeList?.map((notice) => (
-          <TeamNoticeItem key={notice.teamID} {...notice} />
-        ))}
+        {noticeList?.pages
+          .map((page) => page.result)
+          .flat()
+          .map((notice) => (
+            <TeamNoticeItem key={notice.teamID} {...notice} />
+          ))}
+        {isFetchingNextPage && <CommonLoader />}
       </StTeamNoticeItemContainer>
     </>
   );


### PR DESCRIPTION
## ⛓ Related Issues
- close #289 

## 📋 작업 내용
- [x] 알림 조회 페이지에 pagination 적용
- [x] 알림 조회 페이지에서 수락/거절 시 mutation 적용
- [x] 수락/거절/보류 상태를 enum으로 사용

## 📌 PR Point
- union type을 enum으로
enum에 문제가 있다는 글은 읽었지만 가독성도 좋고 깔끔해서 도입했습니다
다른 union 타입들에도 이걸 먹이는게 어떨지?!

**Before**
```ts
export type TeamNoticeItem = {
  ...
  status: 'PENDING' | 'ACCEPT' | 'DECLINE';
};
```

**After**
```ts
export type TeamNoticeItem = {
  ...
  status: TeamNoticeStatus;
};

export enum TeamNoticeStatus {
  PENDING = 'PENDING',
  ACCEPT = 'ACCEPT',
  DECLINE = 'DECLINE',
}
```
- mutation과 신기한 setQueryData함수
```ts
    {
      onSuccess: () => {
        queryClient.setQueryData('notice', (old: TeamNoticePaginateItems | undefined) => {
          return {
            pages:
              old?.pages?.map((o) => ({
                ...o,
                result: o.result.map((r) =>
                  r.teamID === teamID ? { ...r, status: TeamNoticeStatus.DECLINE } : r,
                ),
              })) ?? [],
          };
        });
      },
    },
```
이 코드가 무슨 의미냐면...  지금 'notice'캐시에는 페이지네이션 한 결과물들이 저장되어있는데  success했을 경우에 그걸 쫙 순회하면서 **방금 내가 초대 거절 버튼을 누른 팀의 id를 가진 아이템을 찾아서 상태를 DECLINE으로 업데이트해주겠다**는 것이에요

사실 invalidate queries하면 지금까지 받아왔던 모든 데이터를 다 날리고 다시 받아오는 거고, setQuery하면 있는 데이터에서 바뀐 부분만 수정해주는 거니까 후자가 더 정석인 방법인 것 같아요

차차 도입해보면 좋을 것 같습니다!

## 🔬 Reference
- https://react-query.tanstack.com/guides/optimistic-updates
- https://codesandbox.io/s/spring-wind-i87i4?from-embed=&file=/src/App.js