### PR TITLE
팀 나가기 및 팀장 권한 위임 모달 구현

### DIFF
--- a/src/infrastructure/api/team.ts
+++ b/src/infrastructure/api/team.ts
@@ -53,4 +53,6 @@ export interface TeamService {
   deleteFeedback(feedbackID: number): Promise<{ isSuccess: boolean }>;
   deleteIssue(issueID: number): Promise<{ isSuccess: boolean }>;
   editTeamMember(teamID: number, newUserIdList: string): Promise<{ isSuccess: boolean }>;
+  leaveTeam(teamID: number): Promise<{ isSuccess: boolean }>;
+  delegateHost(teamID: number, newHostID: number): Promise<{ isSuccess: boolean }>;
 }

--- a/src/infrastructure/mock/team.ts
+++ b/src/infrastructure/mock/team.ts
@@ -143,6 +143,13 @@ export function teamDataMock(): TeamService {
     return { isSuccess: true };
   };
 
+  const leaveTeam = async () => {
+    return { isSuccess: true };
+  };
+  const delegateHost = async () => {
+    return { isSuccess: true };
+  };
+
   return {
     getIssueInfo,
     postFeedbackBookmark,
@@ -169,6 +176,8 @@ export function teamDataMock(): TeamService {
     deleteFeedback,
     deleteIssue,
     editTeamMember,
+    leaveTeam,
+    delegateHost,
   };
 }
 

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -401,6 +401,26 @@ export function teamDataRemote(): TeamService {
     return { isSuccess: response.success };
   };
 
+  const leaveTeam = async (teamID: number) => {
+    const response = await privateAPI
+      .delete({ url: `/team/member`, data: { teamId: teamID } })
+      .catch((error: AxiosError) => {
+        if (error.response?.status === STATUS_CODE.FORBIDDEN)
+          throw new ForbiddenError('소속된 팀이 아니므로 요청을 수행할 수 없습니다.');
+      });
+    return { isSuccess: response.success };
+  };
+
+  const delegateHost = async (teamID: number, newHostID: number) => {
+    const response = await privateAPI
+      .put({ url: `/team/host`, data: { teamId: teamID, memberId: newHostID } })
+      .catch((error: AxiosError) => {
+        if (error.response?.status === STATUS_CODE.FORBIDDEN)
+          throw new ForbiddenError('팀 호스트에게만 권한이 있습니다.');
+      });
+    return { isSuccess: response.success };
+  };
+
   return {
     postFeedbackBookmark,
     getTeamProfile,
@@ -427,5 +447,7 @@ export function teamDataRemote(): TeamService {
     deleteFeedback,
     deleteIssue,
     editTeamMember,
+    leaveTeam,
+    delegateHost,
   };
 }

--- a/src/presentation/components/common/BottomSheet/TeamMain/index.tsx
+++ b/src/presentation/components/common/BottomSheet/TeamMain/index.tsx
@@ -8,10 +8,11 @@ type TeamMainBottomSheetProps = {
   closeBottomSheet: () => void;
   isUserHost: boolean;
   teamID: string;
+  openLeaveModal: () => void;
 };
 
 function TeamMainBottomSheet(props: TeamMainBottomSheetProps) {
-  const { isOpened, closeBottomSheet, isUserHost, teamID } = props;
+  const { isOpened, closeBottomSheet, isUserHost, teamID, openLeaveModal } = props;
   const navigate = useNavigate();
 
   const manageTeamMember = () => {
@@ -20,11 +21,6 @@ function TeamMainBottomSheet(props: TeamMainBottomSheetProps) {
 
   const navigateToEditPage = () => {
     navigate(`/team/${teamID}/edit`);
-  };
-
-  const leaveTeam = () => {
-    // 주영 언니가 이어서 작업할 부분
-    console.log('팀 나가기 팝업');
   };
 
   return (
@@ -45,14 +41,14 @@ function TeamMainBottomSheet(props: TeamMainBottomSheetProps) {
               {
                 icon: icLeaveTeam,
                 label: '팀 나가기',
-                onClick: leaveTeam,
+                onClick: openLeaveModal,
               },
             ]
           : [
               {
                 icon: icLeaveTeam,
                 label: '팀 나가기',
-                onClick: leaveTeam,
+                onClick: openLeaveModal,
               },
             ]
       }

--- a/src/presentation/components/common/Modal/HostDelegation/index.tsx
+++ b/src/presentation/components/common/Modal/HostDelegation/index.tsx
@@ -12,7 +12,13 @@ interface HostDelegationModalProps {
 }
 
 export default function HostDelegationModal(props: HostDelegationModalProps) {
-  const { teamMemberList, newHost, setNewHost, closeModal, onClickDelegateConfirm } = props;
+  const {
+    teamMemberList,
+    newHost,
+    setNewHost,
+    closeModal,
+    onClickDelegateConfirm: confirmDelegation,
+  } = props;
   const profileList = useMemo(
     () =>
       teamMemberList
@@ -38,7 +44,7 @@ export default function HostDelegationModal(props: HostDelegationModalProps) {
       />
       <div>
         <button onClick={closeModal}>취소</button>
-        <button onClick={onClickDelegateConfirm}>확인</button>
+        <button onClick={confirmDelegation}>확인</button>
       </div>
     </StHostDelegationModal>
   );

--- a/src/presentation/components/common/Modal/HostDelegation/index.tsx
+++ b/src/presentation/components/common/Modal/HostDelegation/index.tsx
@@ -20,11 +20,13 @@ export default function HostDelegationModal(props: HostDelegationModalProps) {
       </div>
       <ProfileListSelectable
         isSquare={false}
-        profiles={teamMemberList.slice(1).map((member) => ({
-          id: member.id,
-          profileImage: member.profileImage ?? '',
-          profileName: member.profileName,
-        }))}
+        profiles={teamMemberList
+          .filter((member) => !member.isHost)
+          .map((member) => ({
+            id: member.id,
+            profileImage: member.profileImage ?? '',
+            profileName: member.profileName,
+          }))}
         selectedProfile={newHost}
         setSelectedProfile={setNewHost}
       />

--- a/src/presentation/components/common/Modal/HostDelegation/index.tsx
+++ b/src/presentation/components/common/Modal/HostDelegation/index.tsx
@@ -1,0 +1,37 @@
+import { TeamMemberNoneId, TeamMemberWithHostInfo } from '@api/types/team';
+import ProfileListSelectable from '@components/ProfileListSelectable';
+import { StHostDelegationModal } from './style';
+
+interface HostDelegationModalProps {
+  teamMemberList: TeamMemberWithHostInfo[];
+  newHost: TeamMemberNoneId;
+  setNewHost: (newHost: TeamMemberNoneId) => void;
+  closeModal: () => void;
+  onClickDelegateConfirm: () => void;
+}
+
+export default function HostDelegationModal(props: HostDelegationModalProps) {
+  const { teamMemberList, newHost, setNewHost, closeModal, onClickDelegateConfirm } = props;
+  return (
+    <StHostDelegationModal>
+      <div>관리자 권한 위임</div>
+      <div>
+        {'팀에 반드시 관리자가 존재해야 합니다.' + '\n' + '관리자 권한을 위임할 팀원을 선택하세요.'}
+      </div>
+      <ProfileListSelectable
+        isSquare={false}
+        profiles={teamMemberList.slice(1).map((member) => ({
+          id: member.id,
+          profileImage: member.profileImage ?? '',
+          profileName: member.profileName,
+        }))}
+        selectedProfile={newHost}
+        setSelectedProfile={setNewHost}
+      />
+      <div>
+        <button onClick={closeModal}>취소</button>
+        <button onClick={onClickDelegateConfirm}>확인</button>
+      </div>
+    </StHostDelegationModal>
+  );
+}

--- a/src/presentation/components/common/Modal/HostDelegation/index.tsx
+++ b/src/presentation/components/common/Modal/HostDelegation/index.tsx
@@ -1,5 +1,6 @@
 import { TeamMemberNoneId, TeamMemberWithHostInfo } from '@api/types/team';
 import ProfileListSelectable from '@components/ProfileListSelectable';
+import { useMemo } from 'react';
 import { StHostDelegationModal } from './style';
 
 interface HostDelegationModalProps {
@@ -12,6 +13,17 @@ interface HostDelegationModalProps {
 
 export default function HostDelegationModal(props: HostDelegationModalProps) {
   const { teamMemberList, newHost, setNewHost, closeModal, onClickDelegateConfirm } = props;
+  const profileList = useMemo(
+    () =>
+      teamMemberList
+        .filter((member) => !member.isHost)
+        .map((member) => ({
+          id: member.id,
+          profileImage: member.profileImage ?? '',
+          profileName: member.profileName,
+        })),
+    [teamMemberList],
+  );
   return (
     <StHostDelegationModal>
       <div>관리자 권한 위임</div>
@@ -20,13 +32,7 @@ export default function HostDelegationModal(props: HostDelegationModalProps) {
       </div>
       <ProfileListSelectable
         isSquare={false}
-        profiles={teamMemberList
-          .filter((member) => !member.isHost)
-          .map((member) => ({
-            id: member.id,
-            profileImage: member.profileImage ?? '',
-            profileName: member.profileName,
-          }))}
+        profiles={profileList}
         selectedProfile={newHost}
         setSelectedProfile={setNewHost}
       />

--- a/src/presentation/components/common/Modal/HostDelegation/style.ts
+++ b/src/presentation/components/common/Modal/HostDelegation/style.ts
@@ -1,0 +1,6 @@
+import { COMMON_MODAL } from '@styles/common/modal';
+import styled from 'styled-components';
+
+export const StHostDelegationModal = styled.div`
+  ${COMMON_MODAL}
+`;

--- a/src/presentation/components/common/Modal/HostDelegation/style.ts
+++ b/src/presentation/components/common/Modal/HostDelegation/style.ts
@@ -1,6 +1,34 @@
-import { COMMON_MODAL } from '@styles/common/modal';
 import styled from 'styled-components';
+
+import { COLOR } from '@styles/common/color';
+import { COMMON_MODAL, COMMON_MODAL_BUTTON } from '@styles/common/modal';
+import { FONT_STYLES } from '@styles/common/font-style';
 
 export const StHostDelegationModal = styled.div`
   ${COMMON_MODAL}
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 24px 24px 24px;
+  & > *:nth-child(1) {
+    margin-top: 44px;
+    color: ${COLOR.GRAY_8};
+    ${FONT_STYLES.SB_20_TITLE}
+  }
+  & > *:nth-child(2) {
+    margin-top: 17px;
+    color: ${COLOR.GRAY_5};
+    ${FONT_STYLES.R_15_BODY}
+    line-height: 143.99%;
+    white-space: pre-line;
+    text-align: center;
+  }
+  & > :nth-child(3) {
+    margin-top: 30px;
+    width: 294px;
+  }
+  & > :nth-child(4) {
+    margin-top: 38px;
+    ${COMMON_MODAL_BUTTON}
+  }
 `;

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -94,13 +94,18 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
     }
   };
 
-  const clickLeaveConfirm = () => {
+  const confirmLeave = () => {
     if (teamMemberList.length > 1 && isUserHost) {
       setMode('DELEGATION');
     } else {
       mutateLeave();
       goTeamHome();
     }
+  };
+
+  const confirmDelegationFinal = () => {
+    mutateDelegate();
+    goTeamHome();
   };
 
   const QuestionModal = (
@@ -112,7 +117,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
       </StDescription>
       <div>
         <button onClick={closeModal}>취소</button>
-        <button onClick={clickLeaveConfirm}>확인</button>
+        <button onClick={confirmLeave}>확인</button>
       </div>
     </StCommonModal>
   );
@@ -128,14 +133,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
       </StWarningMessage>
       <div>
         <button onClick={resetModal}>취소</button>
-        <button
-          onClick={() => {
-            mutateDelegate();
-            goTeamHome();
-          }}
-        >
-          확인
-        </button>
+        <button onClick={confirmDelegationFinal}>확인</button>
       </div>
     </StDelegationCheckModal>
   );

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -4,7 +4,7 @@ import { TeamMemberNoneId, TeamMemberWithHostInfo } from '@api/types/team';
 import { StCommonModal, StDescription } from '../style';
 import { IcWarning } from '@assets/icons';
 import ModalWrapper from '@components/common/ModalWrapper';
-import { StWarningMessage } from './style';
+import { StDelegationCheckModal, StWarningMessage } from './style';
 import HostDelegationModal from '../HostDelegation';
 
 interface TeamLeaveModalProps {
@@ -73,8 +73,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   );
 
   const DelegationCheckModal = (
-    <StCommonModal>
-      <IcWarning />
+    <StDelegationCheckModal>
       <StWarningMessage>
         <div>
           <div>{newHost.profileName}</div>
@@ -86,7 +85,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
         <button onClick={resetModal}>취소</button>
         <button onClick={resetModal}>확인</button>
       </div>
-    </StCommonModal>
+    </StDelegationCheckModal>
   );
 
   return <ModalWrapper isOpened={isOpened}> {getModal()} </ModalWrapper>;

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -113,7 +113,9 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
       <IcWarning />
       <div>팀을 나가시겠습니까?</div>
       <StDescription>
-        {'팀에서 나가면' + '\n' + '관리자의 초대 없이 복구할 수 없습니다.'}
+        팀에서 나가면
+        <br />
+        관리자의 초대 없이 복구할 수 없습니다.
       </StDescription>
       <div>
         <button onClick={closeModal}>취소</button>

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+
+import { TeamMemberNoneId, TeamMemberWithHostInfo } from '@api/types/team';
+import { StCommonModal, StDescription } from '../style';
+import { IcWarning } from '@assets/icons';
+import ModalWrapper from '@components/common/ModalWrapper';
+import { StWarningMessage } from './style';
+import HostDelegationModal from '../HostDelegation';
+
+interface TeamLeaveModalProps {
+  isOpened: boolean;
+  teamMemberList: TeamMemberWithHostInfo[];
+  closeModal: () => void;
+  isUserHost: boolean;
+}
+
+export default function TeamLeaveModal(props: TeamLeaveModalProps) {
+  const { isOpened, teamMemberList, closeModal, isUserHost } = props;
+  const teamMemberListWithoutHost = teamMemberList.filter((member) => !member.isHost);
+  const [mode, setMode] = useState<'QUESTION' | 'DELEGATION' | 'DELEGATION_CHECK'>('QUESTION');
+  const firstMember = teamMemberListWithoutHost[0];
+  const [newHost, setNewHost] = useState<TeamMemberNoneId>({
+    id: firstMember.id,
+    profileImage: firstMember.profileImage,
+    profileName: firstMember.profileName,
+  });
+
+  const getModal = () => {
+    switch (mode) {
+      case 'QUESTION':
+        return QuestionModal;
+      case 'DELEGATION':
+        return (
+          <HostDelegationModal
+            teamMemberList={teamMemberList}
+            newHost={newHost}
+            setNewHost={(newHost: TeamMemberNoneId) => setNewHost(newHost)}
+            closeModal={closeModal}
+            onClickDelegateConfirm={() => setMode('DELEGATION_CHECK')}
+          />
+        );
+      case 'DELEGATION_CHECK':
+        return DelegationCheckModal;
+    }
+  };
+
+  const clickLeaveConfirm = () => {
+    if (teamMemberList.length > 1 && isUserHost) {
+      setMode('DELEGATION');
+    } else {
+      // 팀 나가기 요청
+      closeModal();
+    }
+  };
+
+  const QuestionModal = (
+    <StCommonModal>
+      <IcWarning />
+      <div>팀을 나가시겠습니까?</div>
+      <StDescription>
+        {'팀에서 나가면' + '\n' + '관리자의 초대 없이 복구할 수 없습니다.'}
+      </StDescription>
+      <div>
+        <button onClick={closeModal}>취소</button>
+        <button onClick={clickLeaveConfirm}>확인</button>
+      </div>
+    </StCommonModal>
+  );
+
+  const DelegationCheckModal = (
+    <StCommonModal>
+      <IcWarning />
+      <StWarningMessage>
+        <div>
+          <div>{newHost.profileName}</div>
+          <div>님에게 관리자 권한을 위임하고</div>
+        </div>
+        <div>팀을 나가시겠습니까?</div>
+      </StWarningMessage>
+      <div>
+        <button onClick={closeModal}>취소</button>
+        <button onClick={closeModal}>확인</button>
+      </div>
+    </StCommonModal>
+  );
+
+  return <ModalWrapper isOpened={isOpened}> {getModal()} </ModalWrapper>;
+}

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { TeamMemberNoneId, TeamMemberWithHostInfo } from '@api/types/team';
 import { StCommonModal, StDescription } from '../style';
@@ -24,10 +25,16 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
     profileImage: firstMember.profileImage,
     profileName: firstMember.profileName,
   });
+  const navigate = useNavigate();
 
   const resetModal = () => {
     closeModal();
     setMode('QUESTION');
+  };
+
+  const leave = () => {
+    resetModal();
+    navigate('/home/team');
   };
 
   const getModal = () => {
@@ -53,8 +60,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
     if (teamMemberList.length > 1 && isUserHost) {
       setMode('DELEGATION');
     } else {
-      // 팀 나가기 요청
-      resetModal();
+      leave();
     }
   };
 
@@ -83,7 +89,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
       </StWarningMessage>
       <div>
         <button onClick={resetModal}>취소</button>
-        <button onClick={resetModal}>확인</button>
+        <button onClick={leave}>확인</button>
       </div>
     </StDelegationCheckModal>
   );

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -15,11 +15,10 @@ interface TeamLeaveModalProps {
   teamMemberList: TeamMemberWithHostInfo[];
   closeModal: () => void;
   isUserHost: boolean;
-  closeBottomSheet: () => void;
 }
 
 export default function TeamLeaveModal(props: TeamLeaveModalProps) {
-  const { isOpened, teamMemberList, closeModal, isUserHost, closeBottomSheet } = props;
+  const { isOpened, teamMemberList, closeModal, isUserHost } = props;
   const teamMemberListWithoutHost = teamMemberList.filter((member) => !member.isHost);
   const [mode, setMode] = useState<'QUESTION' | 'DELEGATION' | 'DELEGATION_CHECK'>('QUESTION');
   const [newHost, setNewHost] = useState<TeamMemberNoneId | null>(null);
@@ -56,7 +55,6 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
 
   const goTeamHome = () => {
     resetModal();
-    closeBottomSheet();
     navigate('/home/team');
   };
 

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -140,7 +140,9 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
     </StDelegationCheckModal>
   );
 
-  useEffect(() => initNewHost(), []);
+  useEffect(() => {
+    if (teamMemberList.length) initNewHost();
+  }, []);
 
   return <ModalWrapper isOpened={isOpened}> {getModal()} </ModalWrapper>;
 }

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -21,7 +21,6 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   const { isOpened, teamMemberList, closeModal, isUserHost } = props;
   const teamMemberListWithoutHost = teamMemberList.filter((member) => !member.isHost);
   const [mode, setMode] = useState<'QUESTION' | 'DELEGATION' | 'DELEGATION_CHECK'>('QUESTION');
-  const firstMember = teamMemberListWithoutHost[0];
   const [newHost, setNewHost] = useState<TeamMemberNoneId | null>(null);
   const navigate = useNavigate();
   const { teamID } = useParams();
@@ -33,7 +32,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   const { mutate: mutateLeave } = useMutation(leave, {
     onSuccess: () => {
       queryClient.setQueryData('teamProfileData', (old: TeamProfileData | undefined) => {
-        return { profileList: old ? old.profileList.filter((o) => o.id === Number(teamID)) : [] };
+        return { profileList: old ? old.profileList.filter((o) => o.id !== Number(teamID)) : [] };
       });
     },
   });
@@ -127,10 +126,16 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   );
 
   useEffect(() => {
-    setNewHost({
-      id: firstMember.id,
-      profileImage: firstMember.profileImage,
-      profileName: firstMember.profileName,
+    setNewHost(() => {
+      const firstMember =
+        teamMemberList.length === 1 && isUserHost
+          ? teamMemberList[0]
+          : teamMemberListWithoutHost[0];
+      return {
+        id: firstMember.id,
+        profileImage: firstMember.profileImage,
+        profileName: firstMember.profileName,
+      };
     });
   }, []);
 

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -51,6 +51,21 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   const resetModal = () => {
     closeModal();
     setMode('QUESTION');
+    initNewHost();
+  };
+
+  const initNewHost = () => {
+    setNewHost(() => {
+      const firstMember =
+        teamMemberList.length === 1 && isUserHost
+          ? teamMemberList[0]
+          : teamMemberListWithoutHost[0];
+      return {
+        id: firstMember.id,
+        profileImage: firstMember.profileImage,
+        profileName: firstMember.profileName,
+      };
+    });
   };
 
   const goTeamHome = () => {
@@ -125,19 +140,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
     </StDelegationCheckModal>
   );
 
-  useEffect(() => {
-    setNewHost(() => {
-      const firstMember =
-        teamMemberList.length === 1 && isUserHost
-          ? teamMemberList[0]
-          : teamMemberListWithoutHost[0];
-      return {
-        id: firstMember.id,
-        profileImage: firstMember.profileImage,
-        profileName: firstMember.profileName,
-      };
-    });
-  }, []);
+  useEffect(() => initNewHost(), []);
 
   return <ModalWrapper isOpened={isOpened}> {getModal()} </ModalWrapper>;
 }

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -44,7 +44,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   const { mutate: mutateDelegate } = useMutation(delegate, {
     onSuccess: () => {
       queryClient.setQueryData('teamProfileData', (old: TeamProfileData | undefined) => {
-        return { profileList: old ? old.profileList.filter((o) => o.id === Number(teamID)) : [] };
+        return { profileList: old ? old.profileList.filter((o) => o.id !== Number(teamID)) : [] };
       });
     },
   });

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -25,6 +25,11 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
     profileName: firstMember.profileName,
   });
 
+  const resetModal = () => {
+    closeModal();
+    setMode('QUESTION');
+  };
+
   const getModal = () => {
     switch (mode) {
       case 'QUESTION':
@@ -35,7 +40,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
             teamMemberList={teamMemberList}
             newHost={newHost}
             setNewHost={(newHost: TeamMemberNoneId) => setNewHost(newHost)}
-            closeModal={closeModal}
+            closeModal={resetModal}
             onClickDelegateConfirm={() => setMode('DELEGATION_CHECK')}
           />
         );
@@ -49,7 +54,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
       setMode('DELEGATION');
     } else {
       // 팀 나가기 요청
-      closeModal();
+      resetModal();
     }
   };
 
@@ -78,8 +83,8 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
         <div>팀을 나가시겠습니까?</div>
       </StWarningMessage>
       <div>
-        <button onClick={closeModal}>취소</button>
-        <button onClick={closeModal}>확인</button>
+        <button onClick={resetModal}>취소</button>
+        <button onClick={resetModal}>확인</button>
       </div>
     </StCommonModal>
   );

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -15,10 +15,11 @@ interface TeamLeaveModalProps {
   teamMemberList: TeamMemberWithHostInfo[];
   closeModal: () => void;
   isUserHost: boolean;
+  closeBottomSheet: () => void;
 }
 
 export default function TeamLeaveModal(props: TeamLeaveModalProps) {
-  const { isOpened, teamMemberList, closeModal, isUserHost } = props;
+  const { isOpened, teamMemberList, closeModal, isUserHost, closeBottomSheet } = props;
   const teamMemberListWithoutHost = teamMemberList.filter((member) => !member.isHost);
   const [mode, setMode] = useState<'QUESTION' | 'DELEGATION' | 'DELEGATION_CHECK'>('QUESTION');
   const [newHost, setNewHost] = useState<TeamMemberNoneId | null>(null);
@@ -55,6 +56,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
 
   const goTeamHome = () => {
     resetModal();
+    closeBottomSheet();
     navigate('/home/team');
   };
 

--- a/src/presentation/components/common/Modal/TeamLeave/style.ts
+++ b/src/presentation/components/common/Modal/TeamLeave/style.ts
@@ -1,3 +1,36 @@
 import styled from 'styled-components';
 
-export const StWarningMessage = styled.div``;
+import { COLOR } from '@styles/common/color';
+import { FONT_STYLES } from '@styles/common/font-style';
+import { COMMON_MODAL, COMMON_MODAL_BUTTON } from '@styles/common/modal';
+
+export const StWarningMessage = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  & > * {
+    ${FONT_STYLES.R_16_BODY}
+    color: ${COLOR.GRAY_7};
+  }
+  & > *:first-child {
+    display: flex;
+    gap: 3px;
+    & > *:first-child {
+      color: ${COLOR.CORAL_MAIN};
+      ${FONT_STYLES.SB_16_BODY}
+    }
+  }
+`;
+
+export const StDelegationCheckModal = styled.div`
+  ${COMMON_MODAL}
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 42px 24px 24px 24px;
+  & > *:last-child {
+    margin-top: 27px;
+    ${COMMON_MODAL_BUTTON}
+  }
+`;

--- a/src/presentation/components/common/Modal/TeamLeave/style.ts
+++ b/src/presentation/components/common/Modal/TeamLeave/style.ts
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const StWarningMessage = styled.div``;

--- a/src/presentation/components/common/Modal/style.ts
+++ b/src/presentation/components/common/Modal/style.ts
@@ -27,7 +27,6 @@ export const StCommonModal = styled.div`
 
 export const StDescription = styled.div`
   margin-top: 10px;
-  white-space: pre-line;
   color: ${COLOR.GRAY_5};
   ${FONT_STYLES.R_15_BODY}
   line-height: 143.99%;

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -47,17 +47,15 @@ function TeamMain() {
 
   return (
     <>
-      {teamInfoData && (
-        <TeamLeaveModal
-          isOpened={isOpenLeaveModal}
-          teamMemberList={teamInfoData ? teamInfoData.teamMemberList : []}
-          closeModal={() => {
-            setIsOpenLeaveModal(false);
-            setIsBottomSheetOpened(false);
-          }}
-          isUserHost={isUserHost}
-        />
-      )}
+      <TeamLeaveModal
+        isOpened={isOpenLeaveModal}
+        teamMemberList={teamInfoData ? teamInfoData.teamMemberList : []}
+        closeModal={() => {
+          setIsOpenLeaveModal(false);
+          setIsBottomSheetOpened(false);
+        }}
+        isUserHost={isUserHost}
+      />
       <CommonNavigation />
       <StTeamMain>
         {teamInfoData && (

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -12,6 +12,7 @@ import TeamMemberPopup from './MemberPopup';
 import { StTeamMain, StTeamInfo, StCheckWrapper, StMemberName, StOtherMember } from './style';
 import { icPerson, icCoralCheck, icGrayCheck, IcMeatball } from '@assets/icons';
 import { imgEmptyProfile } from '@assets/images';
+import TeamLeaveModal from '@components/common/Modal/TeamLeave';
 
 function TeamMain() {
   const navigate = useNavigate();
@@ -20,6 +21,7 @@ function TeamMain() {
   const [isMemberPopupOpened, setIsMemberPopupOpened] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
   const [isBottomSheetOpened, setIsBottomSheetOpened] = useState(false);
+  const [isOpenLeaveModal, setIsOpenLeaveModal] = useState(false);
   const checkMyIssue = () => setIsChecked((prev) => !prev);
 
   if (teamID === undefined) navigate('/');
@@ -45,6 +47,14 @@ function TeamMain() {
 
   return (
     <>
+      {teamInfoData && (
+        <TeamLeaveModal
+          isOpened={isOpenLeaveModal}
+          teamMemberList={teamInfoData ? teamInfoData.teamMemberList : []}
+          closeModal={() => setIsOpenLeaveModal(false)}
+          isUserHost={isUserHost}
+        />
+      )}
       <CommonNavigation />
       <StTeamMain>
         {teamInfoData && (
@@ -103,6 +113,7 @@ function TeamMain() {
           closeBottomSheet={() => setIsBottomSheetOpened(false)}
           isUserHost={isUserHost}
           teamID={teamID}
+          openLeaveModal={() => setIsOpenLeaveModal(true)}
         />
       )}
     </>

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -53,6 +53,7 @@ function TeamMain() {
           teamMemberList={teamInfoData ? teamInfoData.teamMemberList : []}
           closeModal={() => setIsOpenLeaveModal(false)}
           isUserHost={isUserHost}
+          closeBottomSheet={() => setIsBottomSheetOpened(false)}
         />
       )}
       <CommonNavigation />

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -51,9 +51,11 @@ function TeamMain() {
         <TeamLeaveModal
           isOpened={isOpenLeaveModal}
           teamMemberList={teamInfoData ? teamInfoData.teamMemberList : []}
-          closeModal={() => setIsOpenLeaveModal(false)}
+          closeModal={() => {
+            setIsOpenLeaveModal(false);
+            setIsBottomSheetOpened(false);
+          }}
           isUserHost={isUserHost}
-          closeBottomSheet={() => setIsBottomSheetOpened(false)}
         />
       )}
       <CommonNavigation />


### PR DESCRIPTION
## ⛓ Related Issues
- close #294 

## 📋 작업 내용
- [x] 팀 나가기 중첩 모달 구현(팀 나갈지 질문/권한 위임할 팀원 선택/권한 위임 최종 확인)
- [x] 경우(본인이 팀장-1인팀인지 아닌지, 본인이 팀원)에 따른 팀 나가기 및 팀장 권한 위임 기능 구현

## 📌 PR Point
### 어떤 위험이나 우려가 발견되었는지
- 아직 팀장 권한 위임이 잘 되는지 위임한 유저 계정에서 확인못해봤습니다 잘 나가지긴 합니다 (확인 마치고 머지할게요!)
- TeamLeaveModal 컴포넌트 내부에 모달 컴포넌트 두 개 만들어놨는데 이것도 따로 파일로 뺄까 싶습니다,, 

## 💟 스크린샷

https://user-images.githubusercontent.com/73823388/167317476-9c211c5d-9e89-434f-9e79-1f660df334f4.mov


https://user-images.githubusercontent.com/73823388/167317600-99ad106d-03b0-4fc3-ad4d-42cb7d5cc166.mov

