### PR TITLE
팀/이슈 수정하기 이미지 삭제 기능 추가 및 자잘한 작업 많이

### DIFF
--- a/src/application/hooks/useImageUpload.ts
+++ b/src/application/hooks/useImageUpload.ts
@@ -1,0 +1,37 @@
+import { useRef, useState } from 'react';
+
+export default function useImageUpload() {
+  const [image, setImage] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [bottomSheetOpened, setBottomSheetOpened] = useState(false);
+  const [isImageDeleted, setIsImageDeleted] = useState(false);
+
+  const clickFileInputRef = () => fileInputRef.current && fileInputRef.current.click();
+
+  const removeImage = () => {
+    setIsImageDeleted(true);
+    setImage(null);
+    setBottomSheetOpened(false);
+  };
+
+  const openBottomSheet = () => setBottomSheetOpened(true);
+  const closeBottomSheet = () => setBottomSheetOpened(false);
+
+  const cancelDelete = () => {
+    setBottomSheetOpened(false);
+    setIsImageDeleted(false);
+  };
+
+  return {
+    image,
+    setImage,
+    fileInputRef,
+    bottomSheetOpened,
+    isImageDeleted,
+    clickFileInputRef,
+    removeImage,
+    openBottomSheet,
+    closeBottomSheet,
+    cancelDelete,
+  };
+}

--- a/src/infrastructure/api/team.ts
+++ b/src/infrastructure/api/team.ts
@@ -60,7 +60,8 @@ export interface TeamService {
     issueID: number,
     categoryID: number,
     content: string,
-    image?: File | '',
+    image: File | null,
+    imageStatus: 'NEW' | 'DELETE' | 'NONE',
   ): Promise<{ isSuccess: boolean; image: string | null }>;
   leaveTeam(teamID: number): Promise<{ isSuccess: boolean }>;
   delegateHost(teamID: number, newHostID: number): Promise<{ isSuccess: boolean }>;

--- a/src/infrastructure/api/team.ts
+++ b/src/infrastructure/api/team.ts
@@ -46,7 +46,10 @@ export interface TeamService {
   getTeamEditInfo(teamID: number): Promise<TeamEditInfo<string>>;
   acceptInvitation(teamID: number): Promise<{ isSuccess: boolean }>;
   rejectInvitation(teamID: number): Promise<{ isSuccess: boolean }>;
-  editTeamInfo(teamInfo: TeamEditInfo<ImageFile>): Promise<{ isSuccess: boolean }>;
+  editTeamInfo(
+    teamInfo: TeamEditInfo<ImageFile>,
+    imageStatus: 'NEW' | 'DELETE' | 'NONE',
+  ): Promise<{ isSuccess: boolean }>;
   deleteTeam(teamID: number): Promise<{ isSuccess: boolean }>;
   getNotice(page: number): Promise<TeamNoticeItem[]>;
   getTeamEditMember(teamID: number): Promise<TeamEditMember[]>;

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -419,12 +419,20 @@ export function teamDataRemote(): TeamService {
     issueID: number,
     categoryID: number,
     content: string,
-    image?: File | '',
+    image: File | null,
+    imageStatus: 'NEW' | 'DELETE' | 'NONE',
   ) => {
     const formData = new FormData();
     formData.append('categoryId', categoryID.toString());
     formData.append('content', content);
-    image && formData.append('image', image);
+    switch (imageStatus) {
+      case 'NEW':
+        image !== null && formData.append('image', image);
+        break;
+      case 'DELETE':
+        formData.append('image', '');
+        break;
+    }
     const response = await privateAPI
       .put({
         url: `/team/issue/${issueID}`,

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -427,7 +427,7 @@ export function teamDataRemote(): TeamService {
     formData.append('content', content);
     switch (imageStatus) {
       case 'NEW':
-        image !== null && formData.append('image', image);
+        image && formData.append('image', image);
         break;
       case 'DELETE':
         formData.append('image', '');

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -325,15 +325,24 @@ export function teamDataRemote(): TeamService {
     return { isSuccess: response.success };
   };
 
-  const editTeamInfo = async (teamInfo: TeamEditInfo<ImageFile>) => {
+  const editTeamInfo = async (
+    teamInfo: TeamEditInfo<ImageFile>,
+    imageStatus: 'NEW' | 'DELETE' | 'NONE',
+  ) => {
     const { id, name, description, image } = teamInfo;
     const formData = new FormData();
-    formData.append('teamId', id.toString());
     formData.append('teamName', name);
-    formData.append('image', image ?? '');
     formData.append('description', description);
+    switch (imageStatus) {
+      case 'NEW':
+        image !== null && formData.append('image', image);
+        break;
+      case 'DELETE':
+        formData.append('image', '');
+        break;
+    }
     const response = await privateAPI.put({
-      url: '/team/edit',
+      url: `/team/edit/${id}`,
       data: formData,
       type: 'multipart',
     });

--- a/src/presentation/components/common/FileUpload/index.tsx
+++ b/src/presentation/components/common/FileUpload/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { forwardRef, useEffect, useRef, useState } from 'react';
 
 import { useToast } from '@hooks/useToast';
 import { checkBrowser } from '@utils/browser';
@@ -11,10 +11,12 @@ interface FileUploadProps {
   height: string;
   borderRadius?: string;
   setFile: (e: File) => void;
+  ref?: React.ForwardedRef<HTMLInputElement>;
+  isDeleted?: boolean;
+  cancelDelete?: () => void;
 }
-
-function FileUpload(props: FileUploadProps): React.ReactElement {
-  const { children, width, height, borderRadius = '0px', setFile } = props;
+const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>((props, ref) => {
+  const { children, width, height, borderRadius = '0px', setFile, isDeleted, cancelDelete } = props;
   const imgFileForm = /(.*?)\.(jpg|JPG|jpeg|JPEG|png|PNG|gif|GIF)$/;
   const [newFile, setNewFile] = useState<File | null>(null);
   const [fileThumbnail, setFileThumbnail] = useState('');
@@ -44,6 +46,7 @@ function FileUpload(props: FileUploadProps): React.ReactElement {
           setNewFile(resizedImageFile);
           setFileThumbnail(URL.createObjectURL(imageBlob));
         }
+        cancelDelete && cancelDelete();
       } else {
         fireToast({ content: '이미지 파일을 첨부해주세요' });
       }
@@ -54,7 +57,7 @@ function FileUpload(props: FileUploadProps): React.ReactElement {
     <StFileUpload>
       <input
         hidden={true}
-        ref={inputRef}
+        ref={ref ?? inputRef}
         type="file"
         onChange={fileInputHandler}
         accept="image/jpeg, image/png, image/gif"
@@ -62,18 +65,20 @@ function FileUpload(props: FileUploadProps): React.ReactElement {
       <StUploadBtn onClick={buttonHandler} width={width} height={height}>
         {!newFile ? ( //파일이 없는 경우
           children
-        ) : (
-          //업로드된 파일이 사진일 경우
+        ) : //업로드된 파일이 사진일 경우
+        isDeleted === undefined || !isDeleted ? (
           <StImgPreview
             src={fileThumbnail}
             width={width}
             height={height}
             borderRadius={borderRadius}
           />
+        ) : (
+          children
         )}
       </StUploadBtn>
     </StFileUpload>
   );
-}
+});
 
 export default FileUpload;

--- a/src/presentation/pages/Team/Edit/index.tsx
+++ b/src/presentation/pages/Team/Edit/index.tsx
@@ -27,7 +27,7 @@ export default function TeamEdit() {
   const [isImageDeleted, setIsImageDeleted] = useState(false);
 
   const { data: teamInfo, isSuccess } = useQuery(
-    'teamEditInfo',
+    ['teamEditInfo', teamID],
     async () => await api.teamService.getTeamEditInfo(Number(teamID)),
     {
       useErrorBoundary: true,
@@ -59,7 +59,6 @@ export default function TeamEdit() {
 
   const getImageThumbnail = () => {
     if (teamInfo && teamInfo.image) {
-      console.log('먀?');
       return isImageDeleted ? (
         <ImgTeamDefault />
       ) : (

--- a/src/presentation/pages/Team/Edit/index.tsx
+++ b/src/presentation/pages/Team/Edit/index.tsx
@@ -106,7 +106,11 @@ export default function TeamEdit() {
       />
       <StTeamEdit>
         <div>팀 수정하기</div>
-        <StPhotoUploadWrapper onClick={() => (!image ? clickFileInputRef() : openBottomSheet())}>
+        <StPhotoUploadWrapper
+          onClick={() =>
+            image ? openBottomSheet() : isImageDeleted ? clickFileInputRef() : openBottomSheet()
+          }
+        >
           <PhotoUpload
             ref={fileInputRef}
             width="88px"

--- a/src/presentation/pages/Team/Edit/index.tsx
+++ b/src/presentation/pages/Team/Edit/index.tsx
@@ -37,12 +37,15 @@ export default function TeamEdit() {
 
   const editTeamInfo = async () => {
     if (!teamID) return;
-    await api.teamService.editTeamInfo({
-      id: Number(teamID),
-      name: name,
-      description: description,
-      image: image,
-    });
+    await api.teamService.editTeamInfo(
+      {
+        id: Number(teamID),
+        name: name,
+        description: description,
+        image: image,
+      },
+      image ? 'NEW' : teamInfo?.image && isImageDeleted ? 'DELETE' : 'NONE',
+    );
   };
   const { mutate } = useMutation(editTeamInfo, {
     onSuccess: () => {
@@ -102,9 +105,9 @@ export default function TeamEdit() {
         <div>팀 수정하기</div>
         <StPhotoUploadWrapper
           onClick={() =>
-            image
-              ? setBottomSheetOpened(true)
-              : fileInputRef.current && fileInputRef.current.click()
+            !teamInfo?.image && !image
+              ? fileInputRef.current && fileInputRef.current.click()
+              : setBottomSheetOpened(true)
           }
         >
           <PhotoUpload

--- a/src/presentation/pages/Team/Edit/index.tsx
+++ b/src/presentation/pages/Team/Edit/index.tsx
@@ -64,13 +64,8 @@ export default function TeamEdit() {
   });
 
   const getImageThumbnail = () => {
-    if (teamInfo && teamInfo.image) {
-      return isImageDeleted ? (
-        <ImgTeamDefault />
-      ) : (
-        <StTeamImage src={teamInfo.image} alt="팀 이미지" />
-      );
-    }
+    if (teamInfo && teamInfo.image && !isImageDeleted)
+      return <StTeamImage src={teamInfo.image} alt="팀 이미지" />;
     return <ImgTeamDefault />;
   };
 

--- a/src/presentation/pages/Team/Edit/index.tsx
+++ b/src/presentation/pages/Team/Edit/index.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import CommonNavigation from '@components/common/Navigation';
 import { StPhotoUploadWrapper, StIcPencil, StTextarea } from '../Register/style';
@@ -13,18 +13,27 @@ import { ImgTeamDefault } from '@assets/images';
 import CommonModal from '@components/common/Modal';
 import BottomSheet from '@components/common/BottomSheet';
 import { icEdit, icTrash } from '@assets/icons';
+import useImageUpload from '@hooks/useImageUpload';
 
 export default function TeamEdit() {
   const navigate = useNavigate();
   const { teamID } = useParams();
-  const [image, setImage] = useState<File | null>(null);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [isOpenModal, setIsOpenModal] = useState(false);
   const queryClient = useQueryClient();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [bottomSheetOpened, setBottomSheetOpened] = useState(false);
-  const [isImageDeleted, setIsImageDeleted] = useState(false);
+  const {
+    image,
+    setImage,
+    fileInputRef,
+    bottomSheetOpened,
+    isImageDeleted,
+    clickFileInputRef,
+    removeImage,
+    openBottomSheet,
+    closeBottomSheet,
+    cancelDelete,
+  } = useImageUpload();
 
   const { data: teamInfo, isSuccess } = useQuery(
     ['teamEditInfo', teamID],
@@ -53,12 +62,6 @@ export default function TeamEdit() {
       return queryClient.invalidateQueries('teamEditInfo');
     },
   });
-
-  const removeImage = () => {
-    setIsImageDeleted(true);
-    setImage(null);
-    setBottomSheetOpened(false);
-  };
 
   const getImageThumbnail = () => {
     if (teamInfo && teamInfo.image) {
@@ -104,11 +107,7 @@ export default function TeamEdit() {
       <StTeamEdit>
         <div>팀 수정하기</div>
         <StPhotoUploadWrapper
-          onClick={() =>
-            !teamInfo?.image && !image
-              ? fileInputRef.current && fileInputRef.current.click()
-              : setBottomSheetOpened(true)
-          }
+          onClick={() => (!teamInfo?.image && !image ? clickFileInputRef() : openBottomSheet())}
         >
           <PhotoUpload
             ref={fileInputRef}
@@ -117,10 +116,7 @@ export default function TeamEdit() {
             borderRadius="36px"
             setFile={setImage}
             isDeleted={isImageDeleted}
-            cancelDelete={() => {
-              setBottomSheetOpened(false);
-              setIsImageDeleted(false);
-            }}
+            cancelDelete={cancelDelete}
           >
             {getImageThumbnail()}
           </PhotoUpload>
@@ -148,11 +144,11 @@ export default function TeamEdit() {
           {
             icon: icEdit,
             label: '이미지 수정하기',
-            onClick: () => fileInputRef.current && fileInputRef.current.click(),
+            onClick: clickFileInputRef,
           },
           { icon: icTrash, label: '이미지 삭제하기', onClick: removeImage },
         ]}
-        closeBottomSheet={() => setBottomSheetOpened(false)}
+        closeBottomSheet={closeBottomSheet}
       />
     </StRelativeWrapper>
   );

--- a/src/presentation/pages/Team/Edit/index.tsx
+++ b/src/presentation/pages/Team/Edit/index.tsx
@@ -106,9 +106,7 @@ export default function TeamEdit() {
       />
       <StTeamEdit>
         <div>팀 수정하기</div>
-        <StPhotoUploadWrapper
-          onClick={() => (!teamInfo?.image && !image ? clickFileInputRef() : openBottomSheet())}
-        >
+        <StPhotoUploadWrapper onClick={() => (!image ? clickFileInputRef() : openBottomSheet())}>
           <PhotoUpload
             ref={fileInputRef}
             width="88px"

--- a/src/presentation/pages/Team/Issue/Edit/index.tsx
+++ b/src/presentation/pages/Team/Issue/Edit/index.tsx
@@ -21,6 +21,7 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useLoginUser } from '@hooks/useLoginUser';
 import useImageUpload from '@hooks/useImageUpload';
 import BottomSheet from '@components/common/BottomSheet';
+import CommonNavigation from '@components/common/Navigation';
 
 export default function TeamIssueEdit() {
   const navigate = useNavigate();
@@ -148,71 +149,74 @@ export default function TeamIssueEdit() {
   }, []);
 
   return (
-    <StNewIssue>
-      <StTitleWrapper>
-        {teamInfoData && teamInfoData.teamDetail.teamName}에 이슈 수정하기
-      </StTitleWrapper>
-      <p>팀에서 겪은 우리의 이슈를 등록하세요</p>
-      <StQuestionWrapper>이슈의 카테고리를 선택해주세요</StQuestionWrapper>
-      <StCategoryWrapper>
-        {categoryList &&
-          categoryList.map((category) => {
-            return (
-              <StCategory
-                selected={selectedCategory?.id === category.id}
-                key={category.id}
-                onClick={() => {
-                  onClickSelectedHandler(category);
-                }}
-              >
-                {category.name}
-              </StCategory>
-            );
-          })}
-      </StCategoryWrapper>
-      <StQuestionWrapper>팀에서 어떤 일이 있었나요?</StQuestionWrapper>
-      <StTextarea
-        placeholder="팀에서 겪은 상황을 작성해주세요"
-        name="issueTextarea"
-        value={issueTextarea}
-        onChange={onChangeIssue}
-      />
-      <StQuestionWrapper>
-        이슈와 관련된 사진을 업로드해주세요<span>(선택)</span>
-      </StQuestionWrapper>
-      <div onClick={() => (!image ? clickFileInputRef() : openBottomSheet())}>
-        <FileUpload
-          ref={fileInputRef}
-          isDeleted={isImageDeleted}
-          cancelDelete={cancelDelete}
-          width="100%"
-          height="149px"
-          setFile={setImage}
-          borderRadius="16px"
-        >
-          {getImageThumbnail()}
-        </FileUpload>
-      </div>
+    <>
+      <CommonNavigation />
+      <StNewIssue>
+        <StTitleWrapper>
+          {teamInfoData && teamInfoData.teamDetail.teamName}에 이슈 수정하기
+        </StTitleWrapper>
+        <p>팀에서 겪은 우리의 이슈를 등록하세요</p>
+        <StQuestionWrapper>이슈의 카테고리를 선택해주세요</StQuestionWrapper>
+        <StCategoryWrapper>
+          {categoryList &&
+            categoryList.map((category) => {
+              return (
+                <StCategory
+                  selected={selectedCategory?.id === category.id}
+                  key={category.id}
+                  onClick={() => {
+                    onClickSelectedHandler(category);
+                  }}
+                >
+                  {category.name}
+                </StCategory>
+              );
+            })}
+        </StCategoryWrapper>
+        <StQuestionWrapper>팀에서 어떤 일이 있었나요?</StQuestionWrapper>
+        <StTextarea
+          placeholder="팀에서 겪은 상황을 작성해주세요"
+          name="issueTextarea"
+          value={issueTextarea}
+          onChange={onChangeIssue}
+        />
+        <StQuestionWrapper>
+          이슈와 관련된 사진을 업로드해주세요<span>(선택)</span>
+        </StQuestionWrapper>
+        <div onClick={() => (!image ? clickFileInputRef() : openBottomSheet())}>
+          <FileUpload
+            ref={fileInputRef}
+            isDeleted={isImageDeleted}
+            cancelDelete={cancelDelete}
+            width="100%"
+            height="149px"
+            setFile={setImage}
+            borderRadius="16px"
+          >
+            {getImageThumbnail()}
+          </FileUpload>
+        </div>
 
-      <StButton
-        type="submit"
-        onClick={editIssue}
-        disabled={issueTextarea === '' || !selectedCategory || isConfirming}
-      >
-        완료
-      </StButton>
-      <BottomSheet
-        isOpened={bottomSheetOpened}
-        buttonList={[
-          {
-            icon: icEdit,
-            label: '이미지 수정하기',
-            onClick: clickFileInputRef,
-          },
-          { icon: icTrash, label: '이미지 삭제하기', onClick: removeImage },
-        ]}
-        closeBottomSheet={closeBottomSheet}
-      />
-    </StNewIssue>
+        <StButton
+          type="submit"
+          onClick={editIssue}
+          disabled={issueTextarea === '' || !selectedCategory || isConfirming}
+        >
+          완료
+        </StButton>
+        <BottomSheet
+          isOpened={bottomSheetOpened}
+          buttonList={[
+            {
+              icon: icEdit,
+              label: '이미지 수정하기',
+              onClick: clickFileInputRef,
+            },
+            { icon: icTrash, label: '이미지 삭제하기', onClick: removeImage },
+          ]}
+          closeBottomSheet={closeBottomSheet}
+        />
+      </StNewIssue>
+    </>
   );
 }

--- a/src/presentation/pages/Team/Issue/Edit/index.tsx
+++ b/src/presentation/pages/Team/Issue/Edit/index.tsx
@@ -1,4 +1,4 @@
-import { icCamera } from '@assets/icons';
+import { icCamera, icEdit, icTrash } from '@assets/icons';
 import React, { useEffect, useState } from 'react';
 import FileUpload from '@components/common/FileUpload';
 import {
@@ -6,7 +6,7 @@ import {
   StTitleWrapper,
   StQuestionWrapper,
   StCategoryWrapper,
-  StTextera,
+  StTextarea,
   StUploadContainer,
   StButton,
   StPhotoUploadImage,
@@ -19,6 +19,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { api } from '@api/index';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useLoginUser } from '@hooks/useLoginUser';
+import useImageUpload from '@hooks/useImageUpload';
+import BottomSheet from '@components/common/BottomSheet';
 
 export default function TeamIssueEdit() {
   const navigate = useNavigate();
@@ -47,10 +49,21 @@ export default function TeamIssueEdit() {
     },
   );
 
-  const [image, setImage] = useState<File | undefined>();
   const [selectedCategory, setSelectedCategory] = useState<IssueCategory | undefined>(undefined);
   const [issueTextarea, setIssueTextarea] = useState(issueInfo ? issueInfo.title : '');
   const [isConfirming, setIsConfirming] = useState(false);
+  const {
+    image,
+    setImage,
+    fileInputRef,
+    bottomSheetOpened,
+    isImageDeleted,
+    clickFileInputRef,
+    removeImage,
+    openBottomSheet,
+    closeBottomSheet,
+    cancelDelete,
+  } = useImageUpload();
 
   const onChangeIssue = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setIssueTextarea(e.currentTarget.value);
@@ -78,6 +91,7 @@ export default function TeamIssueEdit() {
           selectedCategory.id,
           issueTextarea,
           image,
+          image ? 'NEW' : issueInfo?.team.thumbnail && isImageDeleted ? 'DELETE' : 'NONE',
         );
     },
     {
@@ -110,6 +124,25 @@ export default function TeamIssueEdit() {
     return categoryList.find((category) => category.name === categoryName) ?? categoryList[0];
   };
 
+  const getImageThumbnail = () => {
+    if (issueInfo && issueInfo.team.thumbnail) {
+      return isImageDeleted ? (
+        <StUploadContainer>
+          <StPhotoUploadImage src={icCamera} />
+          <StPhotoUploadMiddleDesc>파일을 선택해서 업로드해주세요</StPhotoUploadMiddleDesc>
+        </StUploadContainer>
+      ) : (
+        <StImage src={issueInfo.team.thumbnail} />
+      );
+    }
+    return (
+      <StUploadContainer>
+        <StPhotoUploadImage src={icCamera} />
+        <StPhotoUploadMiddleDesc>파일을 선택해서 업로드해주세요</StPhotoUploadMiddleDesc>
+      </StUploadContainer>
+    );
+  };
+
   useEffect(() => {
     setSelectedCategory(getCategoryInfoFromName(issueInfo ? issueInfo.category : ''));
   }, []);
@@ -138,7 +171,7 @@ export default function TeamIssueEdit() {
           })}
       </StCategoryWrapper>
       <StQuestionWrapper>팀에서 어떤 일이 있었나요?</StQuestionWrapper>
-      <StTextera
+      <StTextarea
         placeholder="팀에서 겪은 상황을 작성해주세요"
         name="issueTextarea"
         value={issueTextarea}
@@ -147,16 +180,24 @@ export default function TeamIssueEdit() {
       <StQuestionWrapper>
         이슈와 관련된 사진을 업로드해주세요<span>(선택)</span>
       </StQuestionWrapper>
-      <FileUpload width="100%" height="149px" setFile={setImage} borderRadius="16px">
-        {issueInfo && issueInfo.thumbnail ? (
-          <StImage src={issueInfo.thumbnail} />
-        ) : (
-          <StUploadContainer>
-            <StPhotoUploadImage src={icCamera} />
-            <StPhotoUploadMiddleDesc>파일을 선택해서 업로드해주세요</StPhotoUploadMiddleDesc>
-          </StUploadContainer>
-        )}
-      </FileUpload>
+      <div
+        onClick={() =>
+          !issueInfo?.team.thumbnail && !image ? clickFileInputRef() : openBottomSheet()
+        }
+      >
+        <FileUpload
+          ref={fileInputRef}
+          isDeleted={isImageDeleted}
+          cancelDelete={cancelDelete}
+          width="100%"
+          height="149px"
+          setFile={setImage}
+          borderRadius="16px"
+        >
+          {getImageThumbnail()}
+        </FileUpload>
+      </div>
+
       <StButton
         type="submit"
         onClick={editIssue}
@@ -164,6 +205,18 @@ export default function TeamIssueEdit() {
       >
         완료
       </StButton>
+      <BottomSheet
+        isOpened={bottomSheetOpened}
+        buttonList={[
+          {
+            icon: icEdit,
+            label: '이미지 수정하기',
+            onClick: clickFileInputRef,
+          },
+          { icon: icTrash, label: '이미지 삭제하기', onClick: removeImage },
+        ]}
+        closeBottomSheet={closeBottomSheet}
+      />
     </StNewIssue>
   );
 }

--- a/src/presentation/pages/Team/Issue/Edit/index.tsx
+++ b/src/presentation/pages/Team/Issue/Edit/index.tsx
@@ -183,7 +183,11 @@ export default function TeamIssueEdit() {
         <StQuestionWrapper>
           이슈와 관련된 사진을 업로드해주세요<span>(선택)</span>
         </StQuestionWrapper>
-        <div onClick={() => (!image ? clickFileInputRef() : openBottomSheet())}>
+        <div
+          onClick={() =>
+            image ? openBottomSheet() : isImageDeleted ? clickFileInputRef() : openBottomSheet()
+          }
+        >
           <FileUpload
             ref={fileInputRef}
             isDeleted={isImageDeleted}

--- a/src/presentation/pages/Team/Issue/Edit/index.tsx
+++ b/src/presentation/pages/Team/Issue/Edit/index.tsx
@@ -180,11 +180,7 @@ export default function TeamIssueEdit() {
       <StQuestionWrapper>
         이슈와 관련된 사진을 업로드해주세요<span>(선택)</span>
       </StQuestionWrapper>
-      <div
-        onClick={() =>
-          !issueInfo?.team.thumbnail && !image ? clickFileInputRef() : openBottomSheet()
-        }
-      >
+      <div onClick={() => (!image ? clickFileInputRef() : openBottomSheet())}>
         <FileUpload
           ref={fileInputRef}
           isDeleted={isImageDeleted}

--- a/src/presentation/pages/Team/Issue/Edit/index.tsx
+++ b/src/presentation/pages/Team/Issue/Edit/index.tsx
@@ -126,16 +126,8 @@ export default function TeamIssueEdit() {
   };
 
   const getImageThumbnail = () => {
-    if (issueInfo && issueInfo.team.thumbnail) {
-      return isImageDeleted ? (
-        <StUploadContainer>
-          <StPhotoUploadImage src={icCamera} />
-          <StPhotoUploadMiddleDesc>파일을 선택해서 업로드해주세요</StPhotoUploadMiddleDesc>
-        </StUploadContainer>
-      ) : (
-        <StImage src={issueInfo.team.thumbnail} />
-      );
-    }
+    if (issueInfo && issueInfo.team.thumbnail && !isImageDeleted)
+      return <StImage src={issueInfo.team.thumbnail} />;
     return (
       <StUploadContainer>
         <StPhotoUploadImage src={icCamera} />

--- a/src/presentation/pages/Team/Issue/Edit/index.tsx
+++ b/src/presentation/pages/Team/Issue/Edit/index.tsx
@@ -150,20 +150,19 @@ export default function TeamIssueEdit() {
         <p>팀에서 겪은 우리의 이슈를 등록하세요</p>
         <StQuestionWrapper>이슈의 카테고리를 선택해주세요</StQuestionWrapper>
         <StCategoryWrapper>
-          {categoryList &&
-            categoryList.map((category) => {
-              return (
-                <StCategory
-                  selected={selectedCategory?.id === category.id}
-                  key={category.id}
-                  onClick={() => {
-                    onClickSelectedHandler(category);
-                  }}
-                >
-                  {category.name}
-                </StCategory>
-              );
-            })}
+          {categoryList?.map((category) => {
+            return (
+              <StCategory
+                selected={selectedCategory?.id === category.id}
+                key={category.id}
+                onClick={() => {
+                  onClickSelectedHandler(category);
+                }}
+              >
+                {category.name}
+              </StCategory>
+            );
+          })}
         </StCategoryWrapper>
         <StQuestionWrapper>팀에서 어떤 일이 있었나요?</StQuestionWrapper>
         <StTextarea

--- a/src/presentation/pages/Team/Issue/Edit/style.ts
+++ b/src/presentation/pages/Team/Issue/Edit/style.ts
@@ -50,7 +50,7 @@ export const StSelectWrapper = styled.div`
   align-self: center;
 `;
 
-export const StTextera = styled.textarea`
+export const StTextarea = styled.textarea`
   width: 100%;
   height: 104px;
   border: 1px solid ${COLOR.GRAY_3};


### PR DESCRIPTION
## ⛓ Related Issues
- close #308 

## 📋 작업 내용
- [x] 팀/이슈 수정하기 이미지 삭제 기능 추가
- [x] 팀/이슈 수정 요청 서버 수정 사항 반영하기
- [x] getTeamEditInfo 어떤 팀 수정하다가 다른 팀 수정하러 갔을 때 이전에 수정하려던 팀 캐시 그대로 냄겨져 있는 버그 해결
- [x] 이미지 수정/삭제 핸들 커스텀 훅 만들기 -> 커스텀 훅을 만들었는데도 들고 다녀야 하는 로직이 너무 많아서 새로 컴포넌트를 만들까 고민 중
- [x] 이슈 수정하기에 CommonNavigation 추가 

## 📌 PR Point
이미지 수정/삭제 로직을 중점으로 봐주셔유(FileUpload, TeamIssueEdit===TeamEdit)  나머지는 잔잔바리입니다
이전과 달리 이미지 추가 버튼을 클릭했을 때 조건에 따라 파일 선택창을 띄워야 해서 forwardRef를 FileUpload에 내려줬구요
관련해서 필요한 상태나 값, 함수가 너무 많이 생겨서 커스텀훅을 만들었어요
그런데도 매번 적용할 때마다 똑같이 가져와야 하는 로직이 너무 많아서 나중에 아예 이미지 업로드를 다루는 컴포넌트를 하나 새로 만들까 합니다

바텀 시트 처음 써봤는데 킹왕짱!