### PR TITLE
너가소개서 설문 만들기 부분 디자인 수정사항 다시 반영

### DIFF
--- a/src/infrastructure/mock/neoga.data.ts
+++ b/src/infrastructure/mock/neoga.data.ts
@@ -12,42 +12,42 @@ export const NEOGA_DATA = {
   MAIN_TEMPLATE: [
     {
       id: 1,
-      title: '너가 기억하는\n*나의 첫인상*',
+      title: '너가 기억하는\\n*나의 첫인상*',
       src: 'https://ww.namu.la/s/34abe06e2ac92dc187a850f51930231b0b933b71ef9372e4ad0c4c2084b231c772ff46ccdbed58e1967cfc9415be646acb7cd18fb95d96bf16052c1634e221ea01c72f96f97a4588c0ed1a9c2f53c741723b5794cecea4f8107ad062cc84e0d4',
       backgroundColor: '#434343',
       isCreated: false,
     },
     {
       id: 2,
-      title: '*가장 기억에 남는*\n순간의 내 모습',
+      title: '*가장 기억에 남는*\\n순간의 내 모습',
       src: 'https://ww.namu.la/s/34abe06e2ac92dc187a850f51930231b0b933b71ef9372e4ad0c4c2084b231c772ff46ccdbed58e1967cfc9415be646acb7cd18fb95d96bf16052c1634e221ea01c72f96f97a4588c0ed1a9c2f53c741723b5794cecea4f8107ad062cc84e0d4',
       backgroundColor: '#FF5D84',
       isCreated: false,
     },
     {
       id: 3,
-      title: '내가 가진\n*장점 소개해주기*',
+      title: '내가 가진\\n*장점 소개해주기*',
       src: 'https://ww.namu.la/s/34abe06e2ac92dc187a850f51930231b0b933b71ef9372e4ad0c4c2084b231c772ff46ccdbed58e1967cfc9415be646acb7cd18fb95d96bf16052c1634e221ea01c72f96f97a4588c0ed1a9c2f53c741723b5794cecea4f8107ad062cc84e0d4',
       backgroundColor: '#5451FF',
       isCreated: false,
     },
     {
       id: 4,
-      title: '너가 닮고 싶은\n*나의 일잘러 모습*',
+      title: '너가 닮고 싶은\\n*나의 일잘러 모습*',
       src: 'https://ww.namu.la/s/34abe06e2ac92dc187a850f51930231b0b933b71ef9372e4ad0c4c2084b231c772ff46ccdbed58e1967cfc9415be646acb7cd18fb95d96bf16052c1634e221ea01c72f96f97a4588c0ed1a9c2f53c741723b5794cecea4f8107ad062cc84e0d4',
       backgroundColor: '#3ACE90',
       isCreated: false,
     },
     {
       id: 5,
-      title: '나에게 어울리는\n*제 2의 직업*',
+      title: '나에게 어울리는\\n*제 2의 직업*',
       src: 'https://ww.namu.la/s/34abe06e2ac92dc187a850f51930231b0b933b71ef9372e4ad0c4c2084b231c772ff46ccdbed58e1967cfc9415be646acb7cd18fb95d96bf16052c1634e221ea01c72f96f97a4588c0ed1a9c2f53c741723b5794cecea4f8107ad062cc84e0d4',
       backgroundColor: '#434343',
       isCreated: false,
     },
     {
       id: 6,
-      title: '너가 나에게\n*고마웠던 일*',
+      title: '너가 나에게\\n*고마웠던 일*',
       src: 'https://ww.namu.la/s/34abe06e2ac92dc187a850f51930231b0b933b71ef9372e4ad0c4c2084b231c772ff46ccdbed58e1967cfc9415be646acb7cd18fb95d96bf16052c1634e221ea01c72f96f97a4588c0ed1a9c2f53c741723b5794cecea4f8107ad062cc84e0d4',
       backgroundColor: '#FF5D84',
       isCreated: false,
@@ -60,7 +60,7 @@ export const NEOGA_DATA = {
         title: '가장 기억에 남는 순간의 내 모습',
         subtitle: '나와 함께하면서 기억에 남는 순간은?',
         darkIconImage:
-          'https://firebasestorage.googleapis.com/v0/b/neogasogaeseo-9aaf5.appspot.com/o/d_light_200x200.png?alt=media',
+          'https://ww.namu.la/s/34abe06e2ac92dc187a850f51930231b0b933b71ef9372e4ad0c4c2084b231c772ff46ccdbed58e1967cfc9415be646acb7cd18fb95d96bf16052c1634e221ea01c72f96f97a4588c0ed1a9c2f53c741723b5794cecea4f8107ad062cc84e0d4',
         createdAt: '2022-01-19',
         answer: [
           {
@@ -110,7 +110,7 @@ export const NEOGA_DATA = {
         title: '너가 닮고 싶은 나의 일잘러 모습',
         subtitle: '당신이 닮고 싶었던 능력이 있나요?',
         darkIconImage:
-          'https://firebasestorage.googleapis.com/v0/b/neogasogaeseo-9aaf5.appspot.com/o/d_light_200x200.png?alt=media',
+          'https://ww.namu.la/s/34abe06e2ac92dc187a850f51930231b0b933b71ef9372e4ad0c4c2084b231c772ff46ccdbed58e1967cfc9415be646acb7cd18fb95d96bf16052c1634e221ea01c72f96f97a4588c0ed1a9c2f53c741723b5794cecea4f8107ad062cc84e0d4',
         createdAt: '2022-01-19',
       },
     ],

--- a/src/infrastructure/remote/neoga.ts
+++ b/src/infrastructure/remote/neoga.ts
@@ -11,7 +11,7 @@ export function NeogaDataRemote(): NeogaService {
       return response.data
         ? {
             id: response.data.id,
-            title: response.data.title,
+            title: response.data.title.replace('\\n', ' ').replaceAll('*', ''),
             content: response.data.subtitle.replace('\\n', '\n'),
             isNew: response.data.isNew,
             isBanner: response.data.isBanner,
@@ -41,7 +41,7 @@ export function NeogaDataRemote(): NeogaService {
     if (response.status === STATUS_CODE.OK)
       return response.data.map((data: any) => ({
         id: data.id,
-        title: data.title,
+        title: data.title.replace('\\n', ' ').replaceAll('*', ''),
         content: data.subtitle.replace('\\n', ' '),
         isNew: data.isNew,
         src: data.darkIconImage,
@@ -58,7 +58,7 @@ export function NeogaDataRemote(): NeogaService {
         resultList: response.data.resultList
           ? response.data.resultList.map((result: any) => ({
               id: result.id,
-              title: result.title,
+              title: result.title.replace('\\n', ' ').replaceAll('*', ''),
               darkIconImage: result.darkIconImage,
               createdAt: result.createdAt,
               answer: result.answer.map((comment: any) => ({
@@ -79,7 +79,7 @@ export function NeogaDataRemote(): NeogaService {
           : response.data
           ? response.data.map((result: any) => ({
               id: result.id,
-              title: result.title,
+              title: result.title.replace('\\n', ' ').replaceAll('*', ''),
               darkIconImage: result.darkIconImage,
               createdAt: result.createdAt,
               answer: [],
@@ -97,7 +97,7 @@ export function NeogaDataRemote(): NeogaService {
         resultList: response.data.resultList
           ? response.data.resultList.map((result: any) => ({
               id: result.id,
-              title: result.title.replace('\\n', '\n'),
+              title: result.title.replace('\\n', ' ').replaceAll('*', ''),
               darkIconImage: result.darkIconImage,
               createdAt: result.createdAt,
               answer: result.answer
@@ -120,7 +120,7 @@ export function NeogaDataRemote(): NeogaService {
           : response.data
           ? response.data.map((result: any) => ({
               id: result.id,
-              title: result.title.replace('\\n', '\n'),
+              title: result.title.replace('\\n', ' ').replaceAll('*', ''),
               darkIconImage: result.darkIconImage,
               createdAt: result.createdAt,
               answer: [],
@@ -138,7 +138,7 @@ export function NeogaDataRemote(): NeogaService {
         resultList: response.data.resultList
           ? response.data.resultList.map((result: any) => ({
               id: result.id,
-              title: result.title.replace('\\n', '\n'),
+              title: result.title.replace('\\n', ' ').replaceAll('*', ''),
               subtitle: result.subtitle,
               darkIconImage: result.darkIconImage,
               createdAt: result.createdAt,
@@ -162,7 +162,7 @@ export function NeogaDataRemote(): NeogaService {
           : response.data
           ? response.data.map((result: any) => ({
               id: result.id,
-              title: result.title.replace('\\n', '\n'),
+              title: result.title.replace('\\n', ' ').replaceAll('*', ''),
               subtitle: result.subtitle,
               darkIconImage: result.darkIconImage,
               createdAt: result.createdAt,
@@ -205,7 +205,7 @@ export function NeogaDataRemote(): NeogaService {
     if (response.status === STATUS_CODE.OK) {
       return {
         id: id,
-        title: title,
+        title: title.replace('\\n', '\n').replaceAll('*', ''),
         subtitle: subtitle.replace('\\n', '\n'),
         image: darkIconImage,
       };
@@ -217,7 +217,7 @@ export function NeogaDataRemote(): NeogaService {
     if (!response.data) throw new NotFoundError('해당 유저와 폼 아이디로 생성된 폼이 없습니다.');
     return {
       id: response.data.form.id,
-      title: response.data.form.title,
+      title: response.data.form.title.replace('\\n', '\n').replaceAll('*', ''),
       subtitle: response.data.form.subtitle.replace('\\n', '\n'),
       darkIconImage: response.data.form.darkIconImage,
       createdAt: response.data.form.createdAt,

--- a/src/infrastructure/remote/neoga.ts
+++ b/src/infrastructure/remote/neoga.ts
@@ -205,7 +205,7 @@ export function NeogaDataRemote(): NeogaService {
     if (response.status === STATUS_CODE.OK) {
       return {
         id: id,
-        title: title.replace('\\n', '\n').replaceAll('*', ''),
+        title: title.replace('\\n', ' ').replaceAll('*', ''),
         subtitle: subtitle.replace('\\n', '\n'),
         image: darkIconImage,
       };

--- a/src/infrastructure/remote/neososeo-form.ts
+++ b/src/infrastructure/remote/neososeo-form.ts
@@ -7,7 +7,7 @@ export function NeososeoFormRemote(): NeososeoFormService {
   const getFormInfo = async (q: string) => {
     const response = await publicAPI.get({ url: `/form/answer?q=${q}` });
     return {
-      title: response.data.form.title,
+      title: response.data.form.title.replace('\\n', '\n').replaceAll('*', ''),
       content: response.data.form.subtitle.replace('\\n', '\n'),
       imageSub: response.data.form.darkIconImage,
       relation: response.data.relationship.map((relation: any) => ({

--- a/src/presentation/components/NeogaMainCard/Item/index.tsx
+++ b/src/presentation/components/NeogaMainCard/Item/index.tsx
@@ -1,4 +1,4 @@
-import { StNeogaMainCardItem } from './style';
+import { StNeogaMainCardItem, StTitle } from './style';
 
 interface NeogaMainCardItemProps {
   id: number;
@@ -10,11 +10,15 @@ interface NeogaMainCardItemProps {
 
 function NeogaMainCardItem(props: NeogaMainCardItemProps) {
   const { id, title, src, backgroundColor, onItemClick } = props;
+  const [firstLine, secondLine] = title.split('\\n');
+  const isFirstLineBold = firstLine.includes('*');
+  const isSecondLineBold = secondLine.includes('*');
 
   return (
     <StNeogaMainCardItem color={backgroundColor} onClick={() => onItemClick(id)}>
       <img src={src} />
-      <div>{title}</div>
+      <StTitle isBold={isFirstLineBold}>{firstLine.replaceAll('*', '')}</StTitle>
+      <StTitle isBold={isSecondLineBold}>{secondLine.replaceAll('*', '')}</StTitle>
     </StNeogaMainCardItem>
   );
 }

--- a/src/presentation/components/NeogaMainCard/Item/style.ts
+++ b/src/presentation/components/NeogaMainCard/Item/style.ts
@@ -23,8 +23,16 @@ export const StNeogaMainCardItem = styled.div`
     margin-bottom: 20px;
   }
 
-  & div {
-    padding-left: 2px;
-    line-height: 144%;
+  & div + div {
+    margin-top: 2px;
   }
+`;
+
+export const StTitle = styled.div<{ isBold: boolean }>`
+  font-weight: ${(props) => (props.isBold ? 600 : 400)};
+  font-size: ${(props) => (props.isBold ? '16px' : '14px')};
+  letter-spacing: ${(props) => (props.isBold ? '-0.015em' : '-0.01em')};
+  color: ${(props) => (props.isBold ? COLOR.GRAY_1 : COLOR.WHITE)};
+  line-height: 140%;
+  padding-left: 2px;
 `;


### PR DESCRIPTION
## ⛓ Related Issues
- close #264  

## 📋 작업 내용
- [x] title 바뀔 부분 전체 수정
- [x] 너가소개서 메인에서 보이는 설문 카드 스타일링

## 📌 PR Point
- 저번에 PR 올렸던 이슈인데 다시 작업하게 된 이유는 데이터베이스가 바뀌면서 title을 쓰는 여러 페이지가 같이 수정되어야 하기 때문입니다.
- `\n` 대신 `\\n`을 쓰게 된 이유를 까먹게 되었는데 혹시 기억난다면 알려주세요 😥
- 피그마 보면서 설문 제목 바뀔 부분 찾아서 `title.replace('\\n', '\n').replaceAll('*', '')` 혹은 `title.replace('\\n', ' ').replaceAll('*', '')`형태로 다 수정했습니다. 혹시 더 바뀔 부분이 있다거나 잘못 바뀐 부분이 있다면 알려주세요!