### PR TITLE
피드백 수정하기 구현

### DIFF
--- a/src/infrastructure/api/team.ts
+++ b/src/infrastructure/api/team.ts
@@ -16,6 +16,7 @@ import {
   SearchedUserResponse,
   TeamEditMember,
   SearchedUserResponseForEdit,
+  FeedbackEditInfo,
 } from './types/team';
 
 export interface TeamService {
@@ -61,4 +62,7 @@ export interface TeamService {
   ): Promise<{ isSuccess: boolean; image: string | null }>;
   leaveTeam(teamID: number): Promise<{ isSuccess: boolean }>;
   delegateHost(teamID: number, newHostID: number): Promise<{ isSuccess: boolean }>;
+  editFeedback(
+    feedback: Omit<FeedbackEditInfo, 'target' | 'targetProfileImage'>,
+  ): Promise<{ isSuccess: boolean }>;
 }

--- a/src/infrastructure/api/types/team.ts
+++ b/src/infrastructure/api/types/team.ts
@@ -191,6 +191,7 @@ export type TeamNoticePaginateItems = {
 };
 
 export type FeedbackEditInfo = {
+  id: string;
   target: string;
   targetID: string;
   targetProfileImage?: string;

--- a/src/infrastructure/api/types/team.ts
+++ b/src/infrastructure/api/types/team.ts
@@ -189,3 +189,10 @@ export type TeamNoticePaginateItems = {
       }[]
     | undefined;
 };
+
+export type FeedbackEditInfo = {
+  target: string;
+  targetID: string;
+  content: string;
+  keywordList: Keyword[];
+};

--- a/src/infrastructure/api/types/team.ts
+++ b/src/infrastructure/api/types/team.ts
@@ -193,6 +193,7 @@ export type TeamNoticePaginateItems = {
 export type FeedbackEditInfo = {
   target: string;
   targetID: string;
+  targetProfileImage?: string;
   content: string;
   keywordList: Keyword[];
 };

--- a/src/infrastructure/mock/team.ts
+++ b/src/infrastructure/mock/team.ts
@@ -155,6 +155,10 @@ export function teamDataMock(): TeamService {
     return { isSuccess: true };
   };
 
+  const editFeedback = async () => {
+    return { isSuccess: true };
+  };
+
   return {
     getIssueInfo,
     postFeedbackBookmark,
@@ -184,6 +188,7 @@ export function teamDataMock(): TeamService {
     editIssue,
     leaveTeam,
     delegateHost,
+    editFeedback,
   };
 }
 

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -1,7 +1,12 @@
 import { AxiosError } from 'axios';
 
 import { ForbiddenError, NotFoundError } from '@api/types/errors';
-import { ImageFile, PostFeedbackRequestBody, TeamEditInfo } from '@api/types/team';
+import {
+  FeedbackEditInfo,
+  ImageFile,
+  PostFeedbackRequestBody,
+  TeamEditInfo,
+} from '@api/types/team';
 import { TeamService } from '@api/team';
 import { NOTICE_PAGE, SEARCHED_USER_PAGE, STATUS_CODE } from '@utils/constant';
 import { getTimeDifference } from '@utils/date';
@@ -449,6 +454,21 @@ export function teamDataRemote(): TeamService {
     return { isSuccess: response.success };
   };
 
+  const editFeedback = async (
+    feedback: Omit<FeedbackEditInfo, 'target' | 'targetProfileImage'>,
+  ) => {
+    const response = await privateAPI.put({
+      url: `/team/feedback/${feedback.id}`,
+      data: {
+        taggedUserId: +feedback.targetID,
+        content: feedback.content,
+        keywordIds: feedback.keywordList.map((keyword) => +keyword.id),
+      },
+    });
+
+    return { isSuccess: response.success };
+  };
+
   return {
     postFeedbackBookmark,
     getTeamProfile,
@@ -478,5 +498,6 @@ export function teamDataRemote(): TeamService {
     editIssue,
     leaveTeam,
     delegateHost,
+    editFeedback,
   };
 }

--- a/src/infrastructure/remote/team.ts
+++ b/src/infrastructure/remote/team.ts
@@ -457,14 +457,19 @@ export function teamDataRemote(): TeamService {
   const editFeedback = async (
     feedback: Omit<FeedbackEditInfo, 'target' | 'targetProfileImage'>,
   ) => {
-    const response = await privateAPI.put({
-      url: `/team/feedback/${feedback.id}`,
-      data: {
-        taggedUserId: +feedback.targetID,
-        content: feedback.content,
-        keywordIds: feedback.keywordList.map((keyword) => +keyword.id),
-      },
-    });
+    const response = await privateAPI
+      .put({
+        url: `/team/feedback/${feedback.id}`,
+        data: {
+          taggedUserId: +feedback.targetID,
+          content: feedback.content,
+          keywordIds: feedback.keywordList.map((keyword) => +keyword.id),
+        },
+      })
+      .catch((error: AxiosError) => {
+        if (error.response?.status === STATUS_CODE.FORBIDDEN)
+          throw new ForbiddenError('수정 권한이 없습니다.');
+      });
 
     return { isSuccess: response.success };
   };

--- a/src/presentation/components/FeedbackCard/Item/index.tsx
+++ b/src/presentation/components/FeedbackCard/Item/index.tsx
@@ -80,6 +80,7 @@ function FeedbackCardItem(props: FeedbackCardProps) {
                 openBottomSheet?.(
                   +id,
                   {
+                    id: id,
                     target: target,
                     targetID: targetProfileID,
                     content: body,

--- a/src/presentation/components/FeedbackCard/Item/index.tsx
+++ b/src/presentation/components/FeedbackCard/Item/index.tsx
@@ -3,14 +3,20 @@ import { useQueryClient } from 'react-query';
 import { useParams } from 'react-router-dom';
 
 import { api } from '@api/index';
-import { FeedbackDetail } from '@api/types/team';
+import { FeedbackDetail, FeedbackEditInfo } from '@api/types/team';
 import ImmutableKeywordList from '@components/common/Keyword/ImmutableList';
 import { useLoginUser } from '@hooks/useLoginUser';
 import { useToast } from '@hooks/useToast';
 import { StFeedbackCard, StHeader, StBody, StBookmark, StMeatBall } from './style';
 
 type FeedbackCardProps = FeedbackDetail & {
-  openBottomSheet?(feedbackID: number, isMine: boolean, isForMe: boolean, isPinned: boolean): void;
+  openBottomSheet?(
+    feedbackID: number,
+    feedback: FeedbackEditInfo,
+    isMine: boolean,
+    isForMe: boolean,
+    isPinned: boolean,
+  ): void;
   parentPage: 'teamsoseo' | 'mypage';
 };
 
@@ -73,6 +79,12 @@ function FeedbackCardItem(props: FeedbackCardProps) {
               onClick={() => {
                 openBottomSheet?.(
                   +id,
+                  {
+                    target: target,
+                    targetID: targetProfileID,
+                    content: body,
+                    keywordList: keywordList,
+                  },
                   writerID !== undefined && +writerID === loginUserID,
                   +targetProfileID === loginUserID || targetProfileID === loginUsername,
                   isBookmarked,

--- a/src/presentation/components/FeedbackCard/List/index.tsx
+++ b/src/presentation/components/FeedbackCard/List/index.tsx
@@ -1,10 +1,11 @@
-import { FeedbackDetail } from '@api/types/team';
+import { FeedbackDetail, FeedbackEditInfo } from '@api/types/team';
 import FeedbackCardItem from '../Item';
 
 type FeedbackCardListProps = {
   feedbacks: FeedbackDetail[];
   openBottomSheet?: (
     feedbackID: number,
+    feedback: FeedbackEditInfo,
     isMine: boolean,
     isForMe: boolean,
     isPinned: boolean,

--- a/src/presentation/components/common/BottomSheet/TeamsoseoPicker/index.tsx
+++ b/src/presentation/components/common/BottomSheet/TeamsoseoPicker/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router';
 import { useQueryClient } from 'react-query';
 
@@ -53,7 +52,7 @@ function TeamsoseoPickerBottomSheet(props: TeamsoseoPickerBottomSheetProps) {
   };
 
   const editFeedback = async () => {
-    console.log('피드백 수정');
+    navigate(`/team/${teamID}/${issueID}/feedback/edit`);
   };
 
   const removeIssue = async () => {

--- a/src/presentation/pages/Team/Issue/Feedback/index.tsx
+++ b/src/presentation/pages/Team/Issue/Feedback/index.tsx
@@ -44,16 +44,10 @@ function TeamIssueFeedback(props: TeamIssueFeedbackProps) {
 
   useEffect(() => {
     if (isEditMode && feedbackEditInfo && teamMembers) {
-      console.log('dd');
       const selectedUserImage = teamMembers.find(
         (member) => member.id === +feedbackEditInfo.targetID,
       )?.profileImage;
       setSelectedUser({
-        id: +feedbackEditInfo.targetID,
-        profileName: feedbackEditInfo.target,
-        profileImage: selectedUserImage ?? '',
-      });
-      console.log({
         id: +feedbackEditInfo.targetID,
         profileName: feedbackEditInfo.target,
         profileImage: selectedUserImage ?? '',

--- a/src/presentation/pages/Team/Issue/Feedback/index.tsx
+++ b/src/presentation/pages/Team/Issue/Feedback/index.tsx
@@ -44,7 +44,7 @@ function TeamIssueFeedback(props: TeamIssueFeedbackProps) {
     api.teamService.getTeamMembers(teamID ?? ''),
   );
 
-  const { mutate } = useMutation(
+  const { mutate: editFeedback } = useMutation(
     async () => {
       if (feedbackEditInfo) {
         const response = await api.teamService.editFeedback({
@@ -103,7 +103,7 @@ function TeamIssueFeedback(props: TeamIssueFeedbackProps) {
   };
 
   const submit = () => {
-    if (isEditMode) mutate();
+    if (isEditMode) editFeedback();
     else onPostFeedback();
   };
   useEffect(() => {

--- a/src/presentation/pages/Team/Issue/Feedback/index.tsx
+++ b/src/presentation/pages/Team/Issue/Feedback/index.tsx
@@ -24,8 +24,8 @@ import { imgEmptyProfile } from '@assets/images';
 
 interface TeamIssueFeedbackProps {
   isEditMode?: boolean;
-  feedbackEditInfo?: FeedbackEditInfo | undefined;
-  closeBottomSheet?: () => void | undefined;
+  feedbackEditInfo?: FeedbackEditInfo;
+  closeBottomSheet?: () => void;
 }
 
 function TeamIssueFeedback(props: TeamIssueFeedbackProps) {

--- a/src/presentation/pages/Team/Issue/Feedback/style.ts
+++ b/src/presentation/pages/Team/Issue/Feedback/style.ts
@@ -91,3 +91,24 @@ export const StEmptyWrapper = styled(StWrapper)`
     margin-top: 10px;
   }
 `;
+
+export const StTargetUser = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  align-items: center;
+  & > img {
+    width: 60px;
+    height: 60px;
+    border-radius: 118px;
+    margin-bottom: 12px;
+  }
+  & > div {
+    ${COLOR.GRAY_8}
+    font-family: 'Pretendard';
+    font-style: normal;
+    font-weight: 600;
+    font-size: 17px;
+    letter-spacing: -0.01em;
+  }
+`;

--- a/src/presentation/pages/Team/Issue/index.tsx
+++ b/src/presentation/pages/Team/Issue/index.tsx
@@ -164,7 +164,7 @@ function TeamIssue() {
         ) : (
           <DeleteIssueModal isOpened closeModal={closeModal} issueID={modalState.id} />
         ))}
-      <Outlet context={{ feedbackEditInfo: feedbackEditInfo }} />
+      <Outlet context={{ feedbackEditInfo: feedbackEditInfo, closeBottomSheet }} />
     </StTeamIssue>
   );
 }

--- a/src/presentation/pages/Team/Issue/index.tsx
+++ b/src/presentation/pages/Team/Issue/index.tsx
@@ -17,7 +17,7 @@ import { useQuery } from 'react-query';
 import TeamsoseoPickerBottomSheet from '@components/common/BottomSheet/TeamsoseoPicker';
 import { useState } from 'react';
 import { useEffect } from 'react';
-import { FeedbackDetail } from '@api/types/team';
+import { FeedbackDetail, FeedbackEditInfo } from '@api/types/team';
 import CommonNavigation from '@components/common/Navigation';
 import { IcMeatball } from '@assets/icons';
 import DeleteFeedbackModal from '@components/common/Modal/DeleteFeedback';
@@ -41,6 +41,7 @@ function TeamIssue() {
   const [modalState, setModalState] = useState<
     { mode: 'issue' | 'feedback'; id: number } | undefined
   >(undefined);
+  const [feedbackEditInfo, setFeedbackEditInfo] = useState<FeedbackEditInfo | undefined>();
 
   const { data: issue } = useQuery(
     ['issueDetailData', `${teamID}-${issueID}`],
@@ -53,7 +54,13 @@ function TeamIssue() {
     if (issue) setFeedbacks(issue.feedbackList);
   }, [issue]);
 
-  const onFeedbackClicked = (id: number, isMine: boolean, isForMe: boolean, isPinned: boolean) => {
+  const onFeedbackClicked = (
+    id: number,
+    feedback: FeedbackEditInfo,
+    isMine: boolean,
+    isForMe: boolean,
+    isPinned: boolean,
+  ) => {
     setIsBottomSheetOpened(true);
     setBottomSheetState({
       id,
@@ -62,6 +69,7 @@ function TeamIssue() {
       isPinned,
       mode: 'feedback',
     });
+    setFeedbackEditInfo(feedback);
   };
 
   const onManageIssueClicked = () => {
@@ -156,7 +164,7 @@ function TeamIssue() {
         ) : (
           <DeleteIssueModal isOpened closeModal={closeModal} issueID={modalState.id} />
         ))}
-      <Outlet />
+      <Outlet context={{ feedbackEditInfo: feedbackEditInfo }} />
     </StTeamIssue>
   );
 }

--- a/src/presentation/routes/TeamRouter.tsx
+++ b/src/presentation/routes/TeamRouter.tsx
@@ -26,6 +26,9 @@ const TeamRouter = () => (
         <Route path="create/*" element={<TeamIssueFeedback />}>
           <Route path="keyword" element={<TeamIssueKeyword />} />
         </Route>
+        <Route path="feedback/edit/*" element={<TeamIssueFeedback isEditMode={true} />}>
+          <Route path="keyword" element={<TeamIssueKeyword />} />
+        </Route>
       </Route>
       <Route path="/:teamID/:issueID/edit" element={<TeamIssueEdit />} />
       <Route path="/alert" element={<TeamAlert />} />


### PR DESCRIPTION
## ⛓ Related Issues
- close #306 

## 📋 작업 내용
- [x] 피드백 수정하기 구현

## 📌 PR Point
### 무슨 이유로 어떻게 코드를 변경했는지
TeamIssueFeedback 컴포넌트를 수정해서 사용했습니다!
제가 봤을 땐 edit만을 위한 로직이 지나치게 많이 사용되지도 않았고 둘 중(등록, 수정) 하나의 모드일 때 쓸데없이 동작하는 것도 없이 깔끔하게 잘 나눠진 것 같습니다 (그렇지만 당근 다른 의견 받아요 ! ! !)
하나만 빼고요..
```tsx
const { data: teamMembers } = useQuery(['teamMemberWithoutSelf', teamID], () =>
    api.teamService.getTeamMembers(teamID ?? ''),
  );
```
처음에는 여기에 enabled 옵션을 줘서 isEditMode가 false일때만 작동하게 했는데 target user 이미지를 받아오기 위해 저것도 받아오게 됐습니다
피드백 수정용 get api가 하나 새로 생기는게 좋을 것 같아요

### 어떤 위험이나 우려가 발견되었는지
여기서 요청 성공 시 굳이 모든 이슈데이터를 다시 받아오게 하지 않고 setQueryData를 하고 싶었는데 리턴 타입 에러 문제를 해결하지 못해서 일단 invalidateQueries를 해줬습니다ㅠ 나중에 다시 보겠습니다,,
```tsx
  const { mutate } = useMutation(
    async () => {
      if (feedbackEditInfo) {
        const response = await api.teamService.editFeedback({
          id: feedbackEditInfo.id,
          targetID: feedbackEditInfo.targetID,
          content: content,
          keywordList: keywordList,
        });
        return response;
      }
    },
    {
      onSuccess: () => {
        closeBottomSheet && closeBottomSheet();
        queryClient.invalidateQueries(['issueDetailData', `${teamID}-${issueID}`]);
        navigate(-1);
      },
    },
  );
```


## 👀 스크린샷 / GIF / 링크
<img width="336" alt="image" src="https://user-images.githubusercontent.com/73823388/168518447-193724ae-e0ce-49a4-9f0a-57c934d9bbdb.png">


