### PR TITLE
팀장 1인팀인데 나가려고 할 시 팀 삭제하기 유도

### DIFF
--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -20,7 +20,9 @@ interface TeamLeaveModalProps {
 export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   const { isOpened, teamMemberList, closeModal, isUserHost } = props;
   const teamMemberListWithoutHost = teamMemberList.filter((member) => !member.isHost);
-  const [mode, setMode] = useState<'QUESTION' | 'DELEGATION' | 'DELEGATION_CHECK'>('QUESTION');
+  const [mode, setMode] = useState<'QUESTION' | 'DELEGATION' | 'DELEGATION_CHECK' | 'DELETE'>(
+    teamMemberListWithoutHost.length > 0 ? 'QUESTION' : 'DELETE',
+  );
   const [newHost, setNewHost] = useState<TeamMemberNoneId | null>(null);
   const navigate = useNavigate();
   const { teamID } = useParams();
@@ -91,6 +93,8 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
         );
       case 'DELEGATION_CHECK':
         return DelegationCheckModal;
+      case 'DELETE':
+        return DeleteModal;
     }
   };
 
@@ -138,6 +142,28 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
         <button onClick={confirmDelegationFinal}>확인</button>
       </div>
     </StDelegationCheckModal>
+  );
+
+  const DeleteModal = (
+    <StCommonModal>
+      <IcWarning />
+      <div>팀을 삭제하시겠습니까?</div>
+      <StDescription>
+        {'다른 팀원이 없기 때문에' + '\n' + '관리자가 나갈 시 팀이 삭제됩니다.'}
+      </StDescription>
+      <div>
+        <button onClick={closeModal}>취소</button>
+        <button
+          onClick={async () => {
+            closeModal();
+            navigate('/home/team');
+            teamID && (await api.teamService.deleteTeam(+teamID));
+          }}
+        >
+          확인
+        </button>
+      </div>
+    </StCommonModal>
   );
 
   useEffect(() => {

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { TeamMemberNoneId, TeamMemberWithHostInfo, TeamProfileData } from '@api/types/team';
@@ -23,7 +23,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   const [mode, setMode] = useState<'QUESTION' | 'DELEGATION' | 'DELEGATION_CHECK' | 'DELETE'>(
     teamMemberListWithoutHost.length > 0 ? 'QUESTION' : 'DELETE',
   );
-  const [newHost, setNewHost] = useState<TeamMemberNoneId | null>(null);
+  const [newHost, setNewHost] = useState<TeamMemberNoneId>(teamMemberListWithoutHost[0]);
   const navigate = useNavigate();
   const { teamID } = useParams();
   const queryClient = useQueryClient();
@@ -53,21 +53,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   const resetModal = () => {
     closeModal();
     setMode('QUESTION');
-    initNewHost();
-  };
-
-  const initNewHost = () => {
-    setNewHost(() => {
-      const firstMember =
-        teamMemberList.length === 1 && isUserHost
-          ? teamMemberList[0]
-          : teamMemberListWithoutHost[0];
-      return {
-        id: firstMember.id,
-        profileImage: firstMember.profileImage,
-        profileName: firstMember.profileName,
-      };
-    });
+    setNewHost(teamMemberListWithoutHost[0]);
   };
 
   const goTeamHome = () => {
@@ -99,7 +85,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   };
 
   const confirmLeave = () => {
-    if (teamMemberList.length > 1 && isUserHost) {
+    if (isUserHost) {
       setMode('DELEGATION');
     } else {
       mutateLeave();
@@ -113,9 +99,8 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   };
 
   const deleteTeam = async () => {
-    closeModal();
-    navigate('/home/team');
     teamID && (await api.teamService.deleteTeam(+teamID));
+    goTeamHome();
   };
 
   const QuestionModal = (
@@ -163,10 +148,6 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
       </div>
     </StCommonModal>
   );
-
-  useEffect(() => {
-    if (teamMemberList.length) initNewHost();
-  }, []);
 
   return <ModalWrapper isOpened={isOpened}> {getModal()} </ModalWrapper>;
 }

--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -112,6 +112,12 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
     goTeamHome();
   };
 
+  const deleteTeam = async () => {
+    closeModal();
+    navigate('/home/team');
+    teamID && (await api.teamService.deleteTeam(+teamID));
+  };
+
   const QuestionModal = (
     <StCommonModal>
       <IcWarning />
@@ -153,15 +159,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
       </StDescription>
       <div>
         <button onClick={closeModal}>취소</button>
-        <button
-          onClick={async () => {
-            closeModal();
-            navigate('/home/team');
-            teamID && (await api.teamService.deleteTeam(+teamID));
-          }}
-        >
-          확인
-        </button>
+        <button onClick={deleteTeam}>확인</button>
       </div>
     </StCommonModal>
   );


### PR DESCRIPTION
## ⛓ Related Issues
- close #331

## 📋 작업 내용
- [x] TeamLeave 중첩 모달에 모드 추가해서 삭제 모달 만들기
- [x] 삭제인 경우 삭제 모드로 해줘서 삭제 요청 할 수 있게 하기

## 📌 PR Point
팀 삭제 요청은 팀 메인에서 정말 바로 딜레이 없이 확인되길래 따로 리액트 쿼리 써서 후처리 안했습니다!

+) 자꾸 이렇게 일욜~월욜에 몰아서 작업해서 미안합니다,,🥲