### PR TITLE
5/26 QA 반영

### DIFF
--- a/src/assets/images/index.ts
+++ b/src/assets/images/index.ts
@@ -18,7 +18,6 @@ export { default as ImgMypage } from './img_mypage.webp';
 export { default as ImgTeamsoseo } from './img_teamsoseo.webp';
 export { default as ImgLoginCharacter } from './img_login_character.svg';
 export { default as ImgLanding } from './img_landing.webp';
-export { default as imgEmptyFeedback } from './img_empty_feedback.svg';
 export { default as imgLinkCreated } from './img_link_created.svg';
 export { ReactComponent as ImgLogoHeader } from './img_logo_header.svg';
 export { ReactComponent as ImgPage1 } from './img_page_1.svg';

--- a/src/presentation/components/NeogaCreateCard/Item/style.ts
+++ b/src/presentation/components/NeogaCreateCard/Item/style.ts
@@ -10,13 +10,13 @@ export const StNeogaCreateCardItem = styled.div<{ idx: number }>`
   white-space: pre-line;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   cursor: pointer;
   box-shadow: 0px 2px 20px rgba(88, 99, 109, 0.05);
   z-index: ${({ idx }) => idx};
   margin-bottom: 12px;
 
   & div {
+    flex: 1;
     & > div:nth-child(1) {
       margin-bottom: 9px;
       color: ${COLOR.GRAY_8};
@@ -32,6 +32,7 @@ export const StNeogaCreateCardItem = styled.div<{ idx: number }>`
   & img {
     width: 52px;
     height: 52px;
+    margin-right: 18px;
   }
 
   & svg {

--- a/src/presentation/components/common/Empty/Feedback/index.tsx
+++ b/src/presentation/components/common/Empty/Feedback/index.tsx
@@ -1,4 +1,3 @@
-import { imgEmptyFeedback } from '@assets/images';
 import { StFeedbackEmptyView } from './style';
 
 interface FeedbackEmptyViewProps {
@@ -10,7 +9,6 @@ function FeedbackEmptyView(props: FeedbackEmptyViewProps) {
 
   return (
     <StFeedbackEmptyView hasThumbnail={hasThumbnail}>
-      <img src={imgEmptyFeedback} />
       <div>아직 피드백이 없어요</div>
       <div>첫번째 피드백을 남겨주세요</div>
     </StFeedbackEmptyView>

--- a/src/presentation/components/common/Empty/Feedback/index.tsx
+++ b/src/presentation/components/common/Empty/Feedback/index.tsx
@@ -9,7 +9,7 @@ function FeedbackEmptyView(props: FeedbackEmptyViewProps) {
 
   return (
     <StFeedbackEmptyView hasThumbnail={hasThumbnail}>
-      <div>아직 피드백이 없어요</div>
+      <div>이슈에 대한 피드백이 없어요</div>
       <div>첫번째 피드백을 남겨주세요</div>
     </StFeedbackEmptyView>
   );

--- a/src/presentation/components/common/Empty/Feedback/style.ts
+++ b/src/presentation/components/common/Empty/Feedback/style.ts
@@ -10,14 +10,14 @@ export const StFeedbackEmptyView = styled.div<{ hasThumbnail: boolean }>`
   justify-content: center;
 
   div:first-of-type {
-    ${FONT_STYLES.SB_20_TITLE}
+    ${FONT_STYLES.SB_18_TITLE}
     color: ${COLOR.GRAY_4};
-    margin-top: 25px;
-    margin-bottom: 8px;
+    margin-top: 44px;
+    margin-bottom: 12px;
   }
 
   div:last-of-type {
-    ${FONT_STYLES.R_15_TITLE}
-    color: ${COLOR.GRAY_4};
+    ${FONT_STYLES.M_14_TITLE}
+    color: ${COLOR.GRAY_35};
   }
 `;

--- a/src/presentation/components/common/FileUpload/index.tsx
+++ b/src/presentation/components/common/FileUpload/index.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, useEffect, useRef, useState } from 'react';
 
 import { useToast } from '@hooks/useToast';
-import { checkBrowser } from '@utils/browser';
 import { resizeImage } from '@utils/image';
 import { StImgPreview, StFileUpload, StUploadBtn } from './style';
 
@@ -38,14 +37,9 @@ const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>((props, ref) =>
     if (e.target.files !== null && e.target.files.length > 0) {
       const file = e.target.files[0];
       if (file.name.match(imgFileForm)) {
-        if (checkBrowser('Internet Explorer')) {
-          setNewFile(file);
-          setFileThumbnail(URL.createObjectURL(file));
-        } else {
-          const { imageBlob, resizedImageFile } = await resizeImage(file, 500);
-          setNewFile(resizedImageFile);
-          setFileThumbnail(URL.createObjectURL(imageBlob));
-        }
+        const { imageBlob, resizedImageFile } = await resizeImage(file, 500);
+        setNewFile(resizedImageFile);
+        setFileThumbnail(URL.createObjectURL(imageBlob));
         cancelDelete && cancelDelete();
       } else {
         fireToast({ content: '이미지 파일을 첨부해주세요' });

--- a/src/presentation/pages/Edit/Profile/index.tsx
+++ b/src/presentation/pages/Edit/Profile/index.tsx
@@ -50,6 +50,8 @@ function MyProfileEdit() {
     } else {
       setErrorMsg('');
     }
+
+    if (!inputId.length) setErrorMsg('');
   }, [inputId, isDuplicate]);
 
   useEffect(() => {

--- a/src/presentation/pages/Edit/Profile/style.ts
+++ b/src/presentation/pages/Edit/Profile/style.ts
@@ -40,6 +40,7 @@ export const StProfileImg = styled.div`
     width: 118px;
     height: 118px;
     border-radius: 50%;
+    object-fit: cover;
   }
 
   svg {

--- a/src/presentation/pages/Neoga/Create/index.tsx
+++ b/src/presentation/pages/Neoga/Create/index.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { useQuery } from 'react-query';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { api } from '@api/index';
-import { imgLogo } from '@assets/images';
 import NeogaCreateCardList from '@components/NeogaCreateCard/List';
 import { StNeogaCreate, StWhiteWrapper, StViewModeSelector } from './style';
+import CommonHeader from '@components/common/Header';
 
 function NeogaCreate() {
   const [viewMode, setViewMode] = useState<'recent' | 'popular'>('popular');
@@ -16,37 +16,37 @@ function NeogaCreate() {
   );
 
   return (
-    <StNeogaCreate>
-      <StWhiteWrapper>
-        <Link to="/home">
-          <img src={imgLogo} alt="로고" />
-        </Link>
-        <div>너가소개서 설문 만들기</div>
-        <div>원하는 설문의 링크를 생성하고 공유해보세요</div>
-        <div>
-          <StViewModeSelector
-            selected={viewMode === 'popular'}
-            onClick={() => setViewMode('popular')}
-          >
-            인기순
-          </StViewModeSelector>
-          <StViewModeSelector
-            selected={viewMode === 'recent'}
-            onClick={() => setViewMode('recent')}
-          >
-            최신순
-          </StViewModeSelector>
-        </div>
-        {allTemplateList && (
-          <NeogaCreateCardList
-            cards={allTemplateList}
-            onItemClick={(id, isCreated) => {
-              navigate(isCreated ? `/neoga/${id}/detail/form` : `/neoga/create/${id}/new`);
-            }}
-          />
-        )}
-      </StWhiteWrapper>
-    </StNeogaCreate>
+    <>
+      <CommonHeader />
+      <StNeogaCreate>
+        <StWhiteWrapper>
+          <div>너가소개서 설문 만들기</div>
+          <div>원하는 설문의 링크를 생성하고 공유해보세요</div>
+          <div>
+            <StViewModeSelector
+              selected={viewMode === 'popular'}
+              onClick={() => setViewMode('popular')}
+            >
+              인기순
+            </StViewModeSelector>
+            <StViewModeSelector
+              selected={viewMode === 'recent'}
+              onClick={() => setViewMode('recent')}
+            >
+              최신순
+            </StViewModeSelector>
+          </div>
+          {allTemplateList && (
+            <NeogaCreateCardList
+              cards={allTemplateList}
+              onItemClick={(id, isCreated) => {
+                navigate(isCreated ? `/neoga/${id}/detail/form` : `/neoga/create/${id}/new`);
+              }}
+            />
+          )}
+        </StWhiteWrapper>
+      </StNeogaCreate>
+    </>
   );
 }
 

--- a/src/presentation/pages/Neoga/Create/style.ts
+++ b/src/presentation/pages/Neoga/Create/style.ts
@@ -17,21 +17,17 @@ export const StWhiteWrapper = styled(StWrapper)`
     width: 44px;
     height: 44px;
   }
-  & > div:nth-child(2) {
-    font-size: 24px;
-    font-weight: 600;
-    line-height: 144%;
-    margin-top: 16px;
+  & > div:nth-child(1) {
+    ${FONT_STYLES.SB_24_TITLE};
+    margin-top: 12px;
   }
-  & > div:nth-child(3) {
-    padding-left: 4px;
-    font-size: 15px;
-    color: ${COLOR.GRAY_5};
-    line-height: 144%;
+  & > div:nth-child(2) {
+    ${FONT_STYLES.R_15_TITLE};
+    color: ${COLOR.GRAY_6};
     margin-top: 12px;
     margin-bottom: 32px;
   }
-  & > div:nth-child(4) {
+  & > div:nth-child(3) {
     display: flex;
     gap: 8px;
     margin-bottom: 20px;

--- a/src/presentation/pages/Team/Main/index.tsx
+++ b/src/presentation/pages/Team/Main/index.tsx
@@ -80,7 +80,7 @@ function TeamMain() {
                     slicedMemberList.map(({ id, profileName, isHost }, index) => (
                       <StMemberName key={id} isHost={isHost}>
                         {profileName}
-                        {index + 1 < slicedMemberList.length ? ',\u00a0' : ''}
+                        {index + 1 < slicedMemberList.length ? ', ' : ''}
                       </StMemberName>
                     ))}
                   {teamInfoData.teamMemberCount > MAX_TEAM_MEMBER && (


### PR DESCRIPTION
## ⛓ Related Issues
- close #345 

## 📋 작업 내용
- [x] 팀원소개서 이슈 디테일 페이지 : 피드백 없을 때 뜨는 엠티뷰에 디자인, 기획 수정사항 반영
- [x] 팀원소개서 팀 디테일 페이지 : 아이폰에서 띄어쓰기 깨지는 문제 해결
- [x] 너가소개서 설문 만들기 페이지 : 설문 카드 디자인대로 반영 안 된 부분 수정, CommonHeader 적용 안 된 부분 수정

## 📌 PR Point
- 5/26 QA 전체 반영은 아니고 이슈에 적은 내용만 작업했습니다. (나머지는 수진언니 슬랙 답장 오면 반영할 예정!)
- 곧 IE 지원 종료라 분기 처리 필요없을 것 같아 관련 코드 제거했습니다.
- 프로필 수정 페이지에서 아이디 입력 안 했을 때 에러 메시지가 없어야 하는데, 5/24 QA 반영 이후로 아래처럼 뜨길래 if문 하나 추가했습니다.
![image](https://user-images.githubusercontent.com/58380158/170825107-41607898-8827-4c6f-8472-2060b87d4965.png)

