### PR TITLE
팀 나가기 1인팀 아닌데 1인팀으로 인식하는 버그 해결

### DIFF
--- a/src/presentation/components/common/Modal/TeamLeave/index.tsx
+++ b/src/presentation/components/common/Modal/TeamLeave/index.tsx
@@ -21,7 +21,7 @@ export default function TeamLeaveModal(props: TeamLeaveModalProps) {
   const { isOpened, teamMemberList, closeModal, isUserHost } = props;
   const teamMemberListWithoutHost = teamMemberList.filter((member) => !member.isHost);
   const [mode, setMode] = useState<'QUESTION' | 'DELEGATION' | 'DELEGATION_CHECK' | 'DELETE'>(
-    teamMemberListWithoutHost.length > 0 ? 'QUESTION' : 'DELETE',
+    teamMemberList.length > 1 ? 'QUESTION' : 'DELETE',
   );
   const [newHost, setNewHost] = useState<TeamMemberNoneId>(teamMemberListWithoutHost[0]);
   const navigate = useNavigate();


### PR DESCRIPTION
## ⛓ Related Issues
- close #353 

## 📋 작업 내용
- [x] 팀 나가기 1인팀 아닌데 1인팀으로 인식하는 버그 해결

## 📌 PR Point
조건을 잘못 설정해놨었습니다,, 한줄 고침!
다른 QA 반영 사항들이랑 묶어서 올리려고 했는데 오늘 QA 때 보려고 고냥 올립니다

