### PR TITLE
7월 다섯째 주 QA 반영 작업

### DIFF
--- a/src/presentation/components/JoinForm/index.tsx
+++ b/src/presentation/components/JoinForm/index.tsx
@@ -8,7 +8,7 @@ import { useToast } from '@hooks/useToast';
 import { kakaoAccessTokenState, kakaoRefreshTokenState } from '@stores/kakao-auth';
 import CommonLabel from '@components/common/Label';
 import CommonInput from '@components/common/Input';
-import { StJoinForm, StInputWrapper, StButton } from './style';
+import { StJoinForm, StButton } from './style';
 import { StErrorMsg } from '@components/common/Input/style';
 import { icProfile, icEmail, icCameraMainCoral } from '@assets/icons';
 import ImageUpload from '@components/common/ImageUpload';
@@ -98,34 +98,32 @@ function JoinForm() {
           }}
           defaultChildren={{
             src: icCameraMainCoral,
-            styles: { width: '32.29px', right: '117px' },
+            styles: { width: '32.29px' },
           }}
           {...imageUploadProps}
         >
           <img src={icProfile} />
         </ImageUpload>
-        <StInputWrapper>
-          <CommonLabel content="아이디" marginTop="44px" marginBottom="20px" />
-          <CommonInput
-            width="100%"
-            placeholder="neososeo_team"
-            onChange={(value) => {
-              setInputId(value);
-            }}
-            maxLength={15}
-            img={icEmail}
-          />
-          <StErrorMsg>{errorMsg}</StErrorMsg>
-          <CommonLabel content="이름" marginTop="44px" marginBottom="20px" />
-          <CommonInput
-            width="100%"
-            placeholder="이름을 입력해주세요"
-            onChange={(value) => {
-              setInputName(value);
-            }}
-            maxLength={6}
-          />
-        </StInputWrapper>
+        <CommonLabel content="아이디" marginTop="44px" marginBottom="20px" />
+        <CommonInput
+          width="100%"
+          placeholder="neososeo_team"
+          onChange={(value) => {
+            setInputId(value);
+          }}
+          maxLength={15}
+          img={icEmail}
+        />
+        <StErrorMsg>{errorMsg}</StErrorMsg>
+        <CommonLabel content="이름" marginTop="44px" marginBottom="20px" />
+        <CommonInput
+          width="100%"
+          placeholder="이름을 입력해주세요"
+          onChange={(value) => {
+            setInputName(value);
+          }}
+          maxLength={6}
+        />
         <StButton
           type="submit"
           onClick={onClickSubmitUserInfo}

--- a/src/presentation/components/JoinForm/style.ts
+++ b/src/presentation/components/JoinForm/style.ts
@@ -7,6 +7,7 @@ import { CORAL_MAIN_BUTTON } from '@styles/common/button';
 export const StJoinForm = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   margin: 0 20px;
 
   h1 {
@@ -15,15 +16,8 @@ export const StJoinForm = styled.div`
     margin: 54px 0px 72px 0px;
   }
 
-  & > *:nth-child(2) {
-    display: flex;
-    justify-content: center;
-  }
-`;
-
-export const StInputWrapper = styled.div`
-  & > div:nth-of-type(2n + 1) {
-    margin-left: 4px;
+  & > *:not(& > *:nth-child(2)) {
+    width: 100%;
   }
 `;
 

--- a/src/presentation/components/common/ImageUpload/index.tsx
+++ b/src/presentation/components/common/ImageUpload/index.tsx
@@ -52,7 +52,7 @@ const ImageUpload = forwardRef<HTMLInputElement, ImageUploadProps>((props, ref) 
   };
 
   return (
-    <StImageUpload onClick={clickImageUpload}>
+    <StImageUpload onClick={clickImageUpload} styles={styles}>
       <input
         hidden={true}
         ref={ref}

--- a/src/presentation/components/common/ImageUpload/style.ts
+++ b/src/presentation/components/common/ImageUpload/style.ts
@@ -8,7 +8,8 @@ export const StThumbnail = styled.img<{ styles: React.CSSProperties }>`
   border-radius: ${(props) => props.styles.borderRadius ?? 0};
 `;
 
-export const StImageUpload = styled.div`
+export const StImageUpload = styled.div<{ styles: React.CSSProperties }>`
+  width: ${(props) => props.styles.width};
   cursor: pointer;
   position: relative;
 `;

--- a/src/presentation/pages/Preferences/ServiceCenter/index.tsx
+++ b/src/presentation/pages/Preferences/ServiceCenter/index.tsx
@@ -12,7 +12,7 @@ import { useToast } from '@hooks/useToast';
 import { StTitle, StSubTitle, StForm, StFormTitle, StTextarea, StButton } from '../style';
 import BottomSheet from '@components/common/BottomSheet';
 import ImageUpload from '@components/common/ImageUpload';
-import { StPhotoUploadMiddleDesc, StUploadContainer } from '@pages/Team/Issue/NewIssue/style';
+import { StUploadContainer } from '@pages/Team/Issue/NewIssue/style';
 
 function ServiceCenterPage() {
   const navigate = useNavigate();
@@ -99,7 +99,7 @@ function ServiceCenterPage() {
           >
             <StUploadContainer>
               <IcCamera />
-              <StPhotoUploadMiddleDesc>파일을 선택해서 업로드해주세요</StPhotoUploadMiddleDesc>
+              <div>파일을 선택해서 업로드해주세요</div>
             </StUploadContainer>
           </ImageUpload>
         </div>

--- a/src/presentation/pages/Team/Issue/NewIssue/index.tsx
+++ b/src/presentation/pages/Team/Issue/NewIssue/index.tsx
@@ -14,7 +14,6 @@ import {
   StUploadContainer,
   StButton,
   StPhotoUploadImage,
-  StPhotoUploadMiddleDesc,
   StCategory,
 } from './style';
 import { icCamera } from '@assets/icons';
@@ -117,7 +116,7 @@ function TeamNewIssue() {
         >
           <StUploadContainer>
             <StPhotoUploadImage src={icCamera} />
-            <StPhotoUploadMiddleDesc>파일을 선택해서 업로드해주세요</StPhotoUploadMiddleDesc>
+            <div>파일을 선택해서 업로드해주세요</div>
           </StUploadContainer>
         </ImageUpload>
         <StButton

--- a/src/presentation/pages/Team/Issue/NewIssue/style.ts
+++ b/src/presentation/pages/Team/Issue/NewIssue/style.ts
@@ -67,15 +67,18 @@ export const StTextarea = styled.textarea`
 `;
 
 export const StUploadContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
   width: 100%;
   height: 149px;
   border: 1.4px dashed ${COLOR.GRAY_3};
   border-radius: 16px;
-  color: ${COLOR.GRAY_5};
-  font-size: 16px;
-  line-height: 100%;
+  ${FONT_STYLES.R_16_TITLE};
+  color: ${COLOR.GRAY_4};
   background-color: white;
-  padding-top: 25px;
+  padding-top: 28px;
   text-align: center;
 `;
 
@@ -90,12 +93,6 @@ export const StButton = styled.button`
   :not(:disabled) {
     background-color: ${COLOR.CORAL_MAIN};
   }
-`;
-
-export const StPhotoUploadMiddleDesc = styled.div`
-  ${FONT_STYLES.R_16_TITLE};
-  color: ${COLOR.GRAY_4};
-  margin-top: 14px;
 `;
 
 export const StPhotoUploadImage = styled.img`

--- a/src/presentation/pages/Team/Register/index.tsx
+++ b/src/presentation/pages/Team/Register/index.tsx
@@ -77,7 +77,7 @@ function TeamRegister() {
             }}
             defaultChildren={{
               src: icPencil,
-              styles: { width: '24px', right: '262px' },
+              styles: { width: '24px' },
             }}
             {...imageUploadProps}
           >

--- a/src/presentation/pages/Team/Register/index.tsx
+++ b/src/presentation/pages/Team/Register/index.tsx
@@ -64,62 +64,67 @@ function TeamRegister() {
 
   return (
     <StWrapper>
-      {isMemberSelectMode && <TeamMemberAddForRegister onClickSubmitButton={closeMembers} />}
-      <StTeamRegister>
-        <CommonNavigation />
-        <div>
-          <StTitle>팀 등록하기</StTitle>
-          <ImageUpload
-            styles={{
-              width: '88px',
-              height: '88px',
-              borderRadius: '30px',
-            }}
-            defaultChildren={{
-              src: icPencil,
-              styles: { width: '24px' },
-            }}
-            {...imageUploadProps}
-          >
-            <ImgTeamDefault />
-          </ImageUpload>
-          <CommonLabel content="팀 이름" marginTop="32px" marginBottom="18px" />
-          <CommonInput
-            value={name}
-            width="100%"
-            placeholder="팀 이름을 입력해주세요"
-            onChange={(name) => setName(name)}
-          />
-          <CommonLabel content="팀에 관해 간략히 설명해주세요" marginTop="44px" />
-          <StTextarea
-            placeholder="설명을 입력해주세요"
-            value={description}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDescription(e.target.value)}
-          />
-          <CommonLabel content="팀원을 추가해주세요" marginTop="44px" marginBottom="18px" />
-          <ProfileList
-            isSquare={false}
-            profileList={[
-              { id: id, profileName: username, profileImage: profileImage ?? imgEmptyProfile },
-              ...selectedUserList.map((user) => ({
-                id: user.id,
-                profileName: user.name,
-                profileImage: user.image ?? imgEmptyProfile,
-              })),
-            ]}
-            onAddClick={() => setIsMemberSelectMode(true)}
-          />
-          <StSubmitButton
-            onClick={() => {
-              mutate();
-              navigate('/home/team');
-            }}
-            isActive={name.length > 0}
-          >
-            완료
-          </StSubmitButton>
-        </div>
-      </StTeamRegister>
+      {isMemberSelectMode ? (
+        <TeamMemberAddForRegister onClickSubmitButton={closeMembers} />
+      ) : (
+        <StTeamRegister>
+          <CommonNavigation />
+          <div>
+            <StTitle>팀 등록하기</StTitle>
+            <ImageUpload
+              styles={{
+                width: '88px',
+                height: '88px',
+                borderRadius: '30px',
+              }}
+              defaultChildren={{
+                src: icPencil,
+                styles: { width: '24px' },
+              }}
+              {...imageUploadProps}
+            >
+              <ImgTeamDefault />
+            </ImageUpload>
+            <CommonLabel content="팀 이름" marginTop="32px" marginBottom="18px" />
+            <CommonInput
+              value={name}
+              width="100%"
+              placeholder="팀 이름을 입력해주세요"
+              onChange={(name) => setName(name)}
+            />
+            <CommonLabel content="팀에 관해 간략히 설명해주세요" marginTop="44px" />
+            <StTextarea
+              placeholder="설명을 입력해주세요"
+              value={description}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setDescription(e.target.value)
+              }
+            />
+            <CommonLabel content="팀원을 추가해주세요" marginTop="44px" marginBottom="18px" />
+            <ProfileList
+              isSquare={false}
+              profileList={[
+                { id: id, profileName: username, profileImage: profileImage ?? imgEmptyProfile },
+                ...selectedUserList.map((user) => ({
+                  id: user.id,
+                  profileName: user.name,
+                  profileImage: user.image ?? imgEmptyProfile,
+                })),
+              ]}
+              onAddClick={() => setIsMemberSelectMode(true)}
+            />
+            <StSubmitButton
+              onClick={() => {
+                mutate();
+                navigate('/home/team');
+              }}
+              isActive={name.length > 0}
+            >
+              완료
+            </StSubmitButton>
+          </div>
+        </StTeamRegister>
+      )}
       <BottomSheet
         isOpened={bottomSheetOpened}
         buttonList={bottomSheetButtonList}


### PR DESCRIPTION
## ⛓ Related Issues
- close #384 

## 📋 작업 내용
- [x] 이미지 업로드 컴포넌트 defaultChildren 위치 조정 방식 수정
- [x] 이슈 업로드 컨테이너 스타일 통일
- [x] 팀원 추가(팀 등록) 페이지에서 스크롤 시 뒤에 있는 팀 등록 페이지 보이는 버그 해결

## 📌 PR Point
### 이미지 업로드 컴포넌트 defaultChildren 위치 조정 방식 수정
회원 가입 뷰의 카메라 아이콘(defaultChildren) 위치 버그를 고치면서,
이미지 업로드 컴포넌트 래퍼에도 styles prop의 width를 적용시켜 배치하기 더욱 편하도록 했습니다.
따라서 defaultChildren 위치 조정도 더욱 간편해졌습니다
### 이슈 업로드 컨테이너 스타일 통일
위 작업을 수행하니 이슈 업로드 컨테이너(StUploadContainer)의 스타일이 깨졌는데 확인해보니 총 3곳에서 다른 방식으로 이 스타일 컴포넌트를 이용하고 있기에 통일해주었습니다.
그 중 피그마와 폰트 색상이 다른 곳도 있었는데 맞춰주었습니다.
### 팀원 추가(팀 등록) 페이지에서 스크롤 시 뒤에 있는 팀 등록 페이지 보이는 버그 해결
이 페이지는 팀원 추가 뷰가 팀 등록 뷰 위로 올라오는데, 이전에는 selectedUserList가 전역 상태가 아니었기에 컴포넌트 마운트 여부에 영향을 받지 않기 위해 팀 등록 뷰를 그대로 유지시킨 채 팀원 추가 뷰가 위에 떠오르게 했습니다.
그런데 지난 번 리팩토링(https://github.com/Neogasogaeseo/Naega-Web/pull/274) 이후 그럴 필요가 없어져 조건부 렌더링을 통해 두 가지의 뷰 중 하나만 떠있게 하는 것으로 해당 버그를 해결했습니다.
