### PR TITLE
release 브랜치에 Adsense 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://naegasogaeseo-dev.kro.kr/",
   "dependencies": {
     "@craco/craco": "^6.4.3",
+    "@ctrl/react-adsense": "1.6.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,11 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css" />
     <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-4DZZ8ZJJYS"></script>
+    <script
+      async
+      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6625943874572956"
+      crossorigin="anonymous"
+    ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {

--- a/src/presentation/components/GoogleAdsense/index.tsx
+++ b/src/presentation/components/GoogleAdsense/index.tsx
@@ -1,0 +1,20 @@
+import { Adsense } from '@ctrl/react-adsense';
+import { isProduction } from '@utils/constant';
+import { StDummyAdvertiseBlock } from './style';
+
+function GoogleAdsense() {
+  if (!isProduction) {
+    return <StDummyAdvertiseBlock />;
+  }
+
+  return (
+    <Adsense
+      client="ca-pub-6625943874572956"
+      slot="8554867589"
+      layout="display"
+      style={{ width: '100%', height: '50px', position: 'absolute', top: 0, left: 0 }}
+    />
+  );
+}
+
+export default GoogleAdsense;

--- a/src/presentation/components/GoogleAdsense/style.ts
+++ b/src/presentation/components/GoogleAdsense/style.ts
@@ -1,0 +1,11 @@
+import { COLOR } from '@styles/common/color';
+import styled from 'styled-components';
+
+export const StDummyAdvertiseBlock = styled.div`
+  height: 50px;
+  background-color: ${COLOR.WHITE};
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+`;

--- a/src/presentation/pages/NeososeoForm/Finish/index.tsx
+++ b/src/presentation/pages/NeososeoForm/Finish/index.tsx
@@ -1,4 +1,5 @@
 import { ImgAnswerDone } from '@assets/images';
+import GoogleAdsense from '@components/GoogleAdsense';
 import { useNavigate } from 'react-router-dom';
 import { StButton } from '../style';
 import { StBody, StNeososeoFinish } from './style';
@@ -8,6 +9,7 @@ function NeososeoFormFinish() {
 
   return (
     <StNeososeoFinish>
+      <GoogleAdsense />
       <StBody>
         <ImgAnswerDone />
         <div>답변이 전달되었어요</div>

--- a/src/presentation/pages/NeososeoForm/Finish/style.ts
+++ b/src/presentation/pages/NeososeoForm/Finish/style.ts
@@ -5,29 +5,25 @@ import styled from 'styled-components';
 export const StBody = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
+  padding-bottom: 2px;
+  & > div:nth-child(2) {
+    color: ${COLOR.GRAY_8};
+    ${FONT_STYLES.SB_20_TITLE}
+  }
+  & > div:nth-child(3) {
+    margin-top: 8px;
+    color: ${COLOR.GRAY_5};
+    ${FONT_STYLES.R_15_TITLE}
+  }
 `;
 
 export const StNeososeoFinish = styled.div`
   height: 100vh;
   width: 100%;
-  padding: 50px 20px;
+  padding: 0 20px 50px 20px;
   display: grid;
   grid-template-rows: auto 58px;
-  & > div:nth-child(1) {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding-bottom: 52px;
-    & > div:nth-child(2) {
-      color: ${COLOR.GRAY_8};
-      ${FONT_STYLES.SB_20_TITLE}
-    }
-    & > div:nth-child(3) {
-      margin-top: 8px;
-      color: ${COLOR.GRAY_5};
-      ${FONT_STYLES.R_15_TITLE}
-    }
-  }
+  position: relative;
 `;

--- a/src/presentation/pages/NeososeoForm/index.tsx
+++ b/src/presentation/pages/NeososeoForm/index.tsx
@@ -1,5 +1,6 @@
 import { api } from '@api/index';
 import NeososeoFormHeader from '@components/common/NeososeoFormHeader';
+import GoogleAdsense from '@components/GoogleAdsense';
 import FormRouter from '@routes/FormRouter';
 import { neososeoAnswerState, neososeoFormState } from '@stores/neososeo-form';
 import { useEffect } from 'react';
@@ -23,6 +24,7 @@ function NeososeoFormPage() {
 
   return (
     <StNeososeoFormPage>
+      <GoogleAdsense />
       {neososeoForm && (
         <NeososeoFormHeader title={neososeoForm.title} image={neososeoForm.imageSub} />
       )}

--- a/src/presentation/pages/NeososeoForm/style.ts
+++ b/src/presentation/pages/NeososeoForm/style.ts
@@ -8,11 +8,12 @@ export const StNeososeoFormPage = styled.div`
   width: 100%;
   padding: 50px 0;
   display: grid;
-  grid-template-rows: 70px auto;
+  grid-template-rows: 120px auto;
   position: relative;
 
   & > *:first-child {
     padding: 0 20px;
+    padding-top: 50px;
   }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,6 +1096,13 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-12.0.0.tgz#a9583a75c3f150667771f30b60d9f059473e62c4"
   integrity sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg==
 
+"@ctrl/react-adsense@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@ctrl/react-adsense/-/react-adsense-1.6.0.tgz#8761bbb13934bf4c9acc520041463050cd96d032"
+  integrity sha512-FlekDNpaSkXpxVH9ic9p3fue3FTQl/Cwqv/DG8ZbN00XL6aujHsArCPo0ElnBBB3imGLtnL3q01L/PrB+5NahA==
+  dependencies:
+    tslib "^2.4.0"
+
 "@emotion/babel-plugin@^11.7.1":
   version "11.7.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz#fec75f38a6ab5b304b0601c74e2a5e77c95e5fa0"
@@ -8481,6 +8488,11 @@ tslib@^2.0.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## ⛓ Related Issues
- close #320 

## 📋 작업 내용
- [x] Adsense 컴포넌트 추가
- [x] 너가소개서 폼 작성 페이지에 Adsense 컴포넌트 넣기, 레이아웃 조금 수정

## 📌 PR Point
- 페이지 전체의 레이아웃을 relative로 주고 Adsense는 absolute로 넣었는데요, 그 이유는 승인 받기 전에는 그 부분에 아무것도 뜨지 않을 거라 레이아웃이 깨질 것이기 때문입니다 .. 
- **PR 보내는 대상 브랜치는 release 브랜치입니다.  머지되면 자동으로 배포됩니다!**

## 🔬 Reference
- 사용한 라이브러리 https://github.com/scttcper/react-adsense
- 애드센스 관련한 문서 - 태그 매개변수 관련 내용 https://support.google.com/adsense/answer/9183460?hl=ko