### PR TITLE
인증 관련 로직 수정(로그인 직후 에러 fix, 로딩 및 에러 관리 방식 변경 등)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { useLoginUser } from '@hooks/useLoginUser';
 import ToastList from '@components/common/Toast/List';
 
 function App() {
-  const { initLoginUser, isAuthenticated } = useLoginUser();
+  const { initLoginUser } = useLoginUser();
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -19,9 +19,8 @@ function App() {
   });
 
   useEffect(() => {
-    if (isAuthenticated) initLoginUser();
-    // TODO else 로그아웃
-  }, [isAuthenticated]);
+    initLoginUser();
+  }, []);
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { useLoginUser } from '@hooks/useLoginUser';
 import ToastList from '@components/common/Toast/List';
 
 function App() {
-  const { initLoginUser } = useLoginUser();
+  const { initLoginUser, isAuthenticated } = useLoginUser();
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -19,8 +19,9 @@ function App() {
   });
 
   useEffect(() => {
-    initLoginUser();
-  }, []);
+    if (isAuthenticated) initLoginUser();
+    // TODO else 로그아웃
+  }, [isAuthenticated]);
 
   return (
     <>

--- a/src/application/hooks/useLoginUser.ts
+++ b/src/application/hooks/useLoginUser.ts
@@ -51,7 +51,7 @@ export function useLoginUser() {
 
   return {
     ...loginUser.user,
-    loginUser,
+    isJoined: loginUser.isJoined,
     setAccessToken,
     setRefreshToken,
     removeToken,

--- a/src/application/hooks/useLoginUser.ts
+++ b/src/application/hooks/useLoginUser.ts
@@ -38,7 +38,7 @@ export function useLoginUser() {
     const refreshToken = localStorage.getItem(TOKEN_KEYS.REFRESH);
     if (accessToken && refreshToken) {
       const user = await api.loginUserService.getUserInfo(accessToken);
-      if (user.userID && user.username && user.profileImage) {
+      if (user.userID && user.username) {
         saveLoginUser({
           isJoined: true,
           accessToken: accessToken,

--- a/src/application/hooks/useLoginUser.ts
+++ b/src/application/hooks/useLoginUser.ts
@@ -21,8 +21,9 @@ export function useLoginUser() {
     initLoginUser();
   };
 
-  const removeAccessToken = () => {
+  const removeToken = () => {
     localStorage.removeItem(TOKEN_KEYS.ACCESS);
+    localStorage.removeItem(TOKEN_KEYS.REFRESH);
     setIsAuthenticated(false);
     setLoginUser(INITIAL_LOGIN_USER);
   };
@@ -54,7 +55,7 @@ export function useLoginUser() {
     ...loginUser.user,
     setAccessToken,
     setRefreshToken,
-    removeAccessToken,
+    removeToken,
     initLoginUser,
     saveLoginUser,
     isAuthenticated,

--- a/src/application/hooks/useLoginUser.ts
+++ b/src/application/hooks/useLoginUser.ts
@@ -9,7 +9,7 @@ import { UnauthorizedError } from '@api/types/errors';
 
 export function useLoginUser() {
   const [loginUser, setLoginUser] = useRecoilState(loginUserState);
-  const [isAuthenticated, setIsAuthenticatedOrigin] = useRecoilState(isAuthenticatedState);
+  const [isAuthenticated, setIsAuthenticated] = useRecoilState(isAuthenticatedState);
   const [error, setError] = useRecoilState(errorState);
 
   const setAccessToken = (accessToken: string) => {
@@ -55,19 +55,14 @@ export function useLoginUser() {
     }
   };
 
-  const setIsAuthenticated = (isAuthenticated: boolean) =>
-    setIsAuthenticatedOrigin(isAuthenticated);
-
   return {
     ...loginUser.user,
-    loginUser,
     setAccessToken,
     setRefreshToken,
     removeAccessToken,
     initLoginUser,
     saveLoginUser,
     isAuthenticated,
-    setIsAuthenticated,
     isLoading: !error && !isAuthenticated,
     error: error,
   };

--- a/src/application/hooks/useLoginUser.ts
+++ b/src/application/hooks/useLoginUser.ts
@@ -9,7 +9,7 @@ import { UnauthorizedError } from '@api/types/errors';
 
 export function useLoginUser() {
   const [loginUser, setLoginUser] = useRecoilState(loginUserState);
-  const [isAuthenticated, setIsAuthenticated] = useRecoilState(isAuthenticatedState);
+  const [isAuthenticated, setIsAuthenticatedOrigin] = useRecoilState(isAuthenticatedState);
   const [error, setError] = useRecoilState(errorState);
 
   const setAccessToken = (accessToken: string) => {
@@ -55,14 +55,19 @@ export function useLoginUser() {
     }
   };
 
+  const setIsAuthenticated = (isAuthenticated: boolean) =>
+    setIsAuthenticatedOrigin(isAuthenticated);
+
   return {
     ...loginUser.user,
+    loginUser,
     setAccessToken,
     setRefreshToken,
     removeAccessToken,
     initLoginUser,
     saveLoginUser,
     isAuthenticated,
+    setIsAuthenticated,
     isLoading: !error && !isAuthenticated,
     error: error,
   };

--- a/src/application/hooks/useLoginUser.ts
+++ b/src/application/hooks/useLoginUser.ts
@@ -1,15 +1,13 @@
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 import { api } from '@api/index';
 import { LoginUser } from '@api/types/user';
-import { errorState } from '@stores/error';
 import { isAuthenticatedState, loginUserState } from '@stores/login-user';
 import { INITIAL_LOGIN_USER, TOKEN_KEYS } from '@utils/constant';
 
 export function useLoginUser() {
   const [loginUser, setLoginUser] = useRecoilState(loginUserState);
   const [isAuthenticated, setIsAuthenticated] = useRecoilState(isAuthenticatedState);
-  const error = useRecoilValue(errorState);
 
   const setAccessToken = (accessToken: string) => {
     localStorage.setItem(TOKEN_KEYS.ACCESS, accessToken);
@@ -59,7 +57,5 @@ export function useLoginUser() {
     initLoginUser,
     saveLoginUser,
     isAuthenticated,
-    isLoading: !error && !isAuthenticated,
-    error: error,
   };
 }

--- a/src/application/hooks/useLoginUser.ts
+++ b/src/application/hooks/useLoginUser.ts
@@ -1,16 +1,15 @@
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { api } from '@api/index';
 import { LoginUser } from '@api/types/user';
 import { errorState } from '@stores/error';
 import { isAuthenticatedState, loginUserState } from '@stores/login-user';
 import { INITIAL_LOGIN_USER, TOKEN_KEYS } from '@utils/constant';
-import { UnauthorizedError } from '@api/types/errors';
 
 export function useLoginUser() {
   const [loginUser, setLoginUser] = useRecoilState(loginUserState);
   const [isAuthenticated, setIsAuthenticated] = useRecoilState(isAuthenticatedState);
-  const [error, setError] = useRecoilState(errorState);
+  const error = useRecoilValue(errorState);
 
   const setAccessToken = (accessToken: string) => {
     localStorage.setItem(TOKEN_KEYS.ACCESS, accessToken);
@@ -36,22 +35,18 @@ export function useLoginUser() {
   };
 
   const initLoginUser = async () => {
-    try {
-      const accessToken = localStorage.getItem(TOKEN_KEYS.ACCESS);
-      const refreshToken = localStorage.getItem(TOKEN_KEYS.REFRESH);
-      if (accessToken && refreshToken) {
-        const user = await api.loginUserService.getUserInfo(accessToken);
-        if (user.userID && user.username && user.profileImage) {
-          saveLoginUser({
-            isJoined: true,
-            accessToken: accessToken,
-            refreshToken: refreshToken,
-            user: user,
-          });
-        }
-      } else throw new UnauthorizedError('토큰이 없습니다');
-    } catch (error) {
-      setError(error);
+    const accessToken = localStorage.getItem(TOKEN_KEYS.ACCESS);
+    const refreshToken = localStorage.getItem(TOKEN_KEYS.REFRESH);
+    if (accessToken && refreshToken) {
+      const user = await api.loginUserService.getUserInfo(accessToken);
+      if (user.userID && user.username && user.profileImage) {
+        saveLoginUser({
+          isJoined: true,
+          accessToken: accessToken,
+          refreshToken: refreshToken,
+          user: user,
+        });
+      }
     }
   };
 

--- a/src/application/hooks/useLoginUser.ts
+++ b/src/application/hooks/useLoginUser.ts
@@ -51,6 +51,7 @@ export function useLoginUser() {
 
   return {
     ...loginUser.user,
+    loginUser,
     setAccessToken,
     setRefreshToken,
     removeToken,

--- a/src/application/stores/error.ts
+++ b/src/application/stores/error.ts
@@ -1,3 +1,0 @@
-import { atom } from 'recoil';
-
-export const errorState = atom<unknown>({ key: 'errorState', default: null });

--- a/src/infrastructure/api/types/errors.ts
+++ b/src/infrastructure/api/types/errors.ts
@@ -58,3 +58,15 @@ export class InternalServerError implements CustomError {
       '현재 내부 서버에 오류가 있거나' + '\n' + '찾고 있는 리소스에 문제가 있어 표시할 수 없어요';
   }
 }
+
+export class BadRequestError implements CustomError {
+  code: 400;
+  name: 'Bad Request Error';
+  message: string;
+
+  constructor(message: string) {
+    this.code = 400;
+    this.name = 'Bad Request Error';
+    this.message = message;
+  }
+}

--- a/src/infrastructure/remote/login-user.ts
+++ b/src/infrastructure/remote/login-user.ts
@@ -30,7 +30,7 @@ export function loginUserRemote(): LoginUserService {
       });
     const { id, profileId, name, image, refreshToken } = response.data.user;
     return {
-      isJoined: profileId.length && name.length,
+      isJoined: profileId.length > 0 && name.length > 0,
       accessToken: response.data.accesstoken,
       refreshToken: refreshToken,
       user: {
@@ -56,7 +56,7 @@ export function loginUserRemote(): LoginUserService {
     if (response.status === STATUS_CODE.OK) {
       const { id, profileId, name, image, refreshToken } = response.data.user;
       return {
-        isJoined: true,
+        isJoined: profileId.length > 0 && name.length > 0,
         accessToken: response.data.accesstoken,
         refreshToken: refreshToken,
         user: {

--- a/src/infrastructure/remote/login-user.ts
+++ b/src/infrastructure/remote/login-user.ts
@@ -3,7 +3,7 @@ import { AxiosError } from 'axios';
 import { LoginUserService } from '@api/login-user';
 import { STATUS_CODE } from '@utils/constant';
 import { publicAPI, privateAPI } from './base';
-import { ForbiddenError, NotFoundError, UnauthorizedError } from '@api/types/errors';
+import { BadRequestError, ForbiddenError } from '@api/types/errors';
 
 export function loginUserRemote(): LoginUserService {
   const getUserInfo = async (token: string) => {
@@ -11,7 +11,7 @@ export function loginUserRemote(): LoginUserService {
       .get({ url: '/user', headers: { accesstoken: token } })
       .catch((error: AxiosError) => {
         if (error.response?.status === STATUS_CODE.BAD_REQUEST)
-          throw new UnauthorizedError('유저 조회에 실패하였습니다.');
+          throw new BadRequestError('유저 조회에 실패하였습니다.');
       });
     return {
       id: response.data.id,
@@ -30,7 +30,7 @@ export function loginUserRemote(): LoginUserService {
       })
       .catch((error: AxiosError) => {
         if (error.response?.status === STATUS_CODE.BAD_REQUEST)
-          throw new NotFoundError('로그인에 실패하였습니다.');
+          throw new BadRequestError('로그인에 실패하였습니다.');
       });
     const { id, profileId, name, image, refreshToken } = response.data.user;
     return {

--- a/src/infrastructure/remote/login-user.ts
+++ b/src/infrastructure/remote/login-user.ts
@@ -3,12 +3,16 @@ import { AxiosError } from 'axios';
 import { LoginUserService } from '@api/login-user';
 import { STATUS_CODE } from '@utils/constant';
 import { publicAPI, privateAPI } from './base';
-import { ForbiddenError, NotFoundError } from '@api/types/errors';
+import { ForbiddenError, NotFoundError, UnauthorizedError } from '@api/types/errors';
 
 export function loginUserRemote(): LoginUserService {
   const getUserInfo = async (token: string) => {
-    const response = await publicAPI.get({ url: '/user', headers: { accesstoken: token } });
-    if (response.status !== STATUS_CODE.OK) throw '유저 조회 실패';
+    const response = await publicAPI
+      .get({ url: '/user', headers: { accesstoken: token } })
+      .catch((error: AxiosError) => {
+        if (error.response?.status === STATUS_CODE.BAD_REQUEST)
+          throw new UnauthorizedError('유저 조회에 실패하였습니다.');
+      });
     return {
       id: response.data.id,
       username: response.data.name,

--- a/src/presentation/pages/OAuthRedirectHandler/index.tsx
+++ b/src/presentation/pages/OAuthRedirectHandler/index.tsx
@@ -4,6 +4,7 @@ import { useMutation } from 'react-query';
 
 import { useLoginUser } from '@hooks/useLoginUser';
 import { api } from '@api/index';
+import { UnauthorizedError } from '@api/types/errors';
 
 const OAuthRedirectHandler = () => {
   const navigate = useNavigate();
@@ -24,7 +25,7 @@ const OAuthRedirectHandler = () => {
   useEffect(() => {
     const authorizationCode = new URL(window.location.href).searchParams.get('code') ?? '';
     if (authorizationCode.length) login(authorizationCode);
-    else throw '카카오 인가 코드 조회 실패';
+    else throw new UnauthorizedError('카카오 인가 코드 조회 실패');
   }, []);
 
   return <></>;

--- a/src/presentation/pages/OAuthRedirectHandler/index.tsx
+++ b/src/presentation/pages/OAuthRedirectHandler/index.tsx
@@ -7,14 +7,14 @@ import { api } from '@api/index';
 
 const OAuthRedirectHandler = () => {
   const navigate = useNavigate();
-  const { setIsAuthenticated } = useLoginUser();
+  const { saveLoginUser } = useLoginUser();
 
   const { mutate: login } = useMutation(
     (authorizationCode: string) => api.loginUserService.postLogin(authorizationCode),
     {
       useErrorBoundary: true,
       onSuccess: (data) => {
-        setIsAuthenticated(true);
+        saveLoginUser(data);
         if (data.isJoined) navigate('/home');
         else navigate('/join');
       },

--- a/src/presentation/pages/OAuthRedirectHandler/index.tsx
+++ b/src/presentation/pages/OAuthRedirectHandler/index.tsx
@@ -7,14 +7,14 @@ import { api } from '@api/index';
 
 const OAuthRedirectHandler = () => {
   const navigate = useNavigate();
-  const { saveLoginUser } = useLoginUser();
+  const { setIsAuthenticated } = useLoginUser();
 
   const { mutate: login } = useMutation(
     (authorizationCode: string) => api.loginUserService.postLogin(authorizationCode),
     {
       useErrorBoundary: true,
       onSuccess: (data) => {
-        saveLoginUser(data);
+        setIsAuthenticated(true);
         if (data.isJoined) navigate('/home');
         else navigate('/join');
       },

--- a/src/presentation/pages/Preferences/index.tsx
+++ b/src/presentation/pages/Preferences/index.tsx
@@ -14,12 +14,12 @@ import {
 } from './style';
 
 function PreferencesPage() {
-  const { removeAccessToken } = useLoginUser();
+  const { removeToken } = useLoginUser();
   const navigate = useNavigate();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const resetUser = () => {
-    removeAccessToken();
+    removeToken();
     navigate('/');
   };
 

--- a/src/presentation/routes/common/PrivateRoute.tsx
+++ b/src/presentation/routes/common/PrivateRoute.tsx
@@ -4,9 +4,9 @@ import ErrorGuard from './ErrorGuard';
 import { useLoginUser } from '@hooks/useLoginUser';
 
 function PrivateRoute() {
-  const { isAuthenticated, loginUser } = useLoginUser();
+  const { isAuthenticated, isJoined } = useLoginUser();
 
-  if (isAuthenticated) return loginUser.isJoined ? <Outlet /> : <Navigate to="/join" />;
+  if (isAuthenticated) return isJoined ? <Outlet /> : <Navigate to="/join" />;
 
   return <Navigate to="/" />;
 }

--- a/src/presentation/routes/common/PrivateRoute.tsx
+++ b/src/presentation/routes/common/PrivateRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import ErrorGuard from './ErrorGuard';
@@ -8,12 +8,17 @@ import { loginUserState } from '@stores/login-user';
 function PrivateRoute() {
   const { isAuthenticated, isLoading, error } = useLoginUser();
   const loginUser = useRecoilValue(loginUserState);
+  const navigate = useNavigate();
+  console.log('isAuth', isAuthenticated);
 
   if (error) throw error;
 
   if (isLoading) return <></>;
 
-  if (isAuthenticated) return loginUser.isJoined ? <Outlet /> : <Navigate to="/join" />;
+  if (isAuthenticated) {
+    if (loginUser.isJoined) return <Outlet />;
+    else navigate('/join');
+  }
 
   return <Navigate to="/" />;
 }

--- a/src/presentation/routes/common/PrivateRoute.tsx
+++ b/src/presentation/routes/common/PrivateRoute.tsx
@@ -6,12 +6,8 @@ import { useLoginUser } from '@hooks/useLoginUser';
 import { loginUserState } from '@stores/login-user';
 
 function PrivateRoute() {
-  const { isAuthenticated, isLoading, error } = useLoginUser();
+  const { isAuthenticated } = useLoginUser();
   const loginUser = useRecoilValue(loginUserState);
-
-  if (error) throw error;
-
-  if (isLoading) return <></>;
 
   if (isAuthenticated) return loginUser.isJoined ? <Outlet /> : <Navigate to="/join" />;
 

--- a/src/presentation/routes/common/PrivateRoute.tsx
+++ b/src/presentation/routes/common/PrivateRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import ErrorGuard from './ErrorGuard';
@@ -8,17 +8,12 @@ import { loginUserState } from '@stores/login-user';
 function PrivateRoute() {
   const { isAuthenticated, isLoading, error } = useLoginUser();
   const loginUser = useRecoilValue(loginUserState);
-  const navigate = useNavigate();
-  console.log('isAuth', isAuthenticated);
 
   if (error) throw error;
 
   if (isLoading) return <></>;
 
-  if (isAuthenticated) {
-    if (loginUser.isJoined) return <Outlet />;
-    else navigate('/join');
-  }
+  if (isAuthenticated) return loginUser.isJoined ? <Outlet /> : <Navigate to="/join" />;
 
   return <Navigate to="/" />;
 }

--- a/src/presentation/routes/common/PrivateRoute.tsx
+++ b/src/presentation/routes/common/PrivateRoute.tsx
@@ -1,13 +1,10 @@
 import { Navigate, Outlet } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 
 import ErrorGuard from './ErrorGuard';
 import { useLoginUser } from '@hooks/useLoginUser';
-import { loginUserState } from '@stores/login-user';
 
 function PrivateRoute() {
-  const { isAuthenticated } = useLoginUser();
-  const loginUser = useRecoilValue(loginUserState);
+  const { isAuthenticated, loginUser } = useLoginUser();
 
   if (isAuthenticated) return loginUser.isJoined ? <Outlet /> : <Navigate to="/join" />;
 


### PR DESCRIPTION
## ⛓ Related Issues
- close #408 

## 📋 작업 내용
- [x] 자잘한 fix
  - [x] isJoined 값 할당 방법 수정 [fbd82c8](https://github.com/Neogasogaeseo/Naega-Web/pull/410/commits/fbd82c8a46da2cc2f2de5e8b4bd3d490b5916a35)
  - [x] 로그아웃 시 리프레시 토큰도 삭제하도록 [dbb601e](https://github.com/Neogasogaeseo/Naega-Web/pull/410/commits/dbb601e8f0ddb274bf8068a1a616ea9328e43cdd)
  - [x] 인증 관련 api 바뀐 에러 코드 반영 [dd898bd](https://github.com/Neogasogaeseo/Naega-Web/pull/410/commits/dd898bd1f8c42ca0ca1a2bec10e3a6e5701f39a6)
- [x] initLoginUser에서 토큰이 없을 시 띄우던 에러 삭제 [a55bb61](https://github.com/Neogasogaeseo/Naega-Web/pull/410/commits/a55bb6136c07e591a94cae8efbfdc951e59d83f4)
- [x] useLoginUser에서 쓰이던 isLoading, error 삭제 [aeb153b](https://github.com/Neogasogaeseo/Naega-Web/pull/410/commits/aeb153bee08c6d57c5283e5506b527b8e3d9726e)

## 📌 PR Point

자잘한 것들 제외하고 크게 보면 결국 useLoginUser의 에러 처리 방식이 변경 됐다고 볼 수 있습니다
그럼으로써 아래 두 문제를 해결했습니다

### 문제
1. 로그인 직후 '토큰이 없습니다' 에러 발생
2. 로그아웃 후 PrivateRoute에서 접근 시 랜딩 페이지로 navigate 되지 않음

<img width="359" alt="image" src="https://user-images.githubusercontent.com/73823388/193447249-1fd18700-86ee-439d-821d-fbc129b4ba04.png">


### 해결

로그인 직후 항상 initLoginUser 내의 '토큰이 없습니다' 에러가 발생하는 문제(문제 1)는, initLoginUser가 실행되는 타이밍이 토큰이 없을 수밖에 없었습니다

[이유]
1. 인가 코드를 받아 OAuthHandler로 리다이렉팅 시 App.tsx가 마운트 되니 실행이 되는데, 그 때는 토큰이 없을 수밖에 없음
2. 그래서 띄우는 에러가 에러 바운더리에 걸림
4. 그런데 기존의 의도는 에러가 뜬다고 해서 에러 바운더리에 걸릴 것이 아닌, 에러를 전역 상태에 저장해놓고 isLoading에 활용하려고 했던 것이었음
5. 그런데 이후에 에러 바운더리를 추가하여 이 로직이 꼬임

[`isLoading`이란]

isLoading은 `!error && !isAuthenticated`임
그리고 isLoading은 PrivateRoute에서 로딩 시 빈 화면을 띄워주게 해주었음

-----------------------------------

이러한 상황에서 아래와 같은 방식으로 수정한다면 문제 1, 2를 모두 해결할 수 있습니다

1. initLoginUser에서 토큰이 없어도 에러 띄우지 않기

initLoginUser에서 토큰이 없어도 에러 띄우지 않도록 하고, useLoginUser에서 관리하던 error state도 삭제했습니다

[이유 1]
토큰이 없다는 것은 useLoginUser의 isAuthenticated가 false라는 것임 (useLoginUser의 saveLoginUser 참고)
따라서 PrivateRoute에 접근할 수 없음
그러니 에러를 띄우지 않아도 문제 없음

[이유 2]
로그인 과정 중에 충분히 토큰이 없는 채로 initLoginUser가 실행될 수 있음
(그렇기에 문제 1이 발생한 것)
그런데 토큰이 없다고 에러를 띄워버리면 에러 바운더리에 걸려버림

[이유 3]
error state는 isLoading에 사용되는데, isLoading을 사용할 필요가 없어져서 (아래 내용 참고)

2. isLoading 사용하지 않기

[이유]
isLoading은 `!error && !isAuthenticated`임
에러가 없으면서 isAuthenticated가 false일 때 즉, isLoading이 true일 때 PrivateRoute 접근 시 빈 화면이 아니라 PublicRoute로 navigate 시켜주면 됨
이 때 빈화면을 띄워주기 때문에 문제 2가 발생했던 것
