### PR TITLE
🚑hotfix: 테스트용 코드를 지우지 않아서 너가소개서 폼 생성 전에도 카드가 뒤집히는 에러 해결

### DIFF
--- a/src/presentation/pages/Neoga/Link/index.tsx
+++ b/src/presentation/pages/Neoga/Link/index.tsx
@@ -67,8 +67,7 @@ export default function NeogaLink() {
     createdFormData && navigate(`/neoga/${createdFormData.formID}/detail/form`);
 
   useEffect(() => {
-    setIsCreated(true);
-    // if (!(viewMode === VIEW_MODE.NEW || viewMode === VIEW_MODE.CREATED)) navigate('/');
+    if (!(viewMode === VIEW_MODE.NEW || viewMode === VIEW_MODE.CREATED)) navigate('/');
     if (viewMode === VIEW_MODE.CREATED) createFormCode();
   }, []);
 


### PR DESCRIPTION
## ⛓ Related Issues
- close #429 

## 📋 작업 내용
- [x] 주석 및 테스트 코드 삭제

## 📌 PR Point
- 진심으로 죄송합니다.. 원인은 [이 커밋](https://github.com/Neogasogaeseo/Naega-Web/commit/7a82b813e15810e8669bf33007463baa15569bc1)에서 테스트용으로 바꿔둔 코드를 다시 되돌리지 않아서 입니다. 
