### PR TITLE
🚑hotfix: 구글 애드 센스로 인해 우측에 생기는 여백 공간 없애기

### DIFF
--- a/src/presentation/components/GoogleAdsense/index.tsx
+++ b/src/presentation/components/GoogleAdsense/index.tsx
@@ -12,7 +12,7 @@ function GoogleAdsense() {
       client="ca-pub-6625943874572956"
       slot="8554867589"
       layout="display"
-      style={{ width: '100%', height: '50px', position: 'absolute', top: 0, left: 0 }}
+      style={{ width: '100%', height: '50px', position: 'absolute', top: 0, left: 0, padding: 0 }}
     />
   );
 }

--- a/src/presentation/components/GoogleAdsense/style.ts
+++ b/src/presentation/components/GoogleAdsense/style.ts
@@ -1,9 +1,7 @@
-import { COLOR } from '@styles/common/color';
 import styled from 'styled-components';
 
 export const StDummyAdvertiseBlock = styled.div`
   height: 50px;
-  background-color: ${COLOR.WHITE};
   position: absolute;
   top: 0;
   left: 0;

--- a/src/presentation/pages/NeososeoForm/index.tsx
+++ b/src/presentation/pages/NeososeoForm/index.tsx
@@ -1,15 +1,23 @@
-import { useParams, Outlet } from 'react-router-dom';
 import GoogleAdsense from '@components/GoogleAdsense';
+import { Outlet, useLocation, useParams } from 'react-router-dom';
 
 import { useGetFormInfo } from '@hooks/queries/neososeo-form';
+import { COLOR } from '@styles/common/color';
 import { StNeososeoFormPage } from './style';
+
+const useBackgroundColor = () => {
+  const location = useLocation();
+  const isStartPage = location.pathname.split('/').length === 3;
+  return isStartPage ? COLOR.GRAY_1 : COLOR.WHITE;
+};
 
 function NeososeoFormPage() {
   const { q } = useParams();
   const { data: neososeoFormData, isLoading } = useGetFormInfo(q ?? '');
+  const backgroundColor = useBackgroundColor();
 
   return (
-    <StNeososeoFormPage>
+    <StNeososeoFormPage bg={backgroundColor}>
       <GoogleAdsense />
       {!isLoading && neososeoFormData !== undefined && <Outlet context={{ neososeoFormData }} />}
     </StNeososeoFormPage>

--- a/src/presentation/pages/NeososeoForm/style.ts
+++ b/src/presentation/pages/NeososeoForm/style.ts
@@ -3,7 +3,7 @@ import { COLOR } from '@styles/common/color';
 import { FONT_STYLES } from '@styles/common/font-style';
 import styled from 'styled-components';
 
-export const StNeososeoFormPage = styled.div`
+export const StNeososeoFormPage = styled.div<{ bg: string }>`
   min-height: 100vh;
   width: 100%;
   display: flex;
@@ -11,6 +11,7 @@ export const StNeososeoFormPage = styled.div`
   position: relative;
   padding-top: 50px;
   position: relative;
+  background-color: ${({ bg }) => bg};
 
   & > *:first-child {
     padding: 0 20px;

--- a/src/presentation/style/common/color.ts
+++ b/src/presentation/style/common/color.ts
@@ -1,4 +1,4 @@
-export const COLOR = {
+export const COLOR: Record<string, string> = {
   CORAL_MAIN: '#FF6262',
   BLACK: '#000000',
   WHITE: '#FFFFFF',


### PR DESCRIPTION
## ⛓ Related Issues
- close #431 

## 📋 작업 내용
- [x] [1] 구글 애즈로 인해 생기는 상단 빈 공간을 배경색으로 메웠습니다.
- [x] [2] 구글 애즈의 padding으로 인해 생기는 우측의 빈 공간을 없앴습니다. 

## 📌 PR Point
- [1] 메우기의 경우, 현재 path가 첫 페이지의 path면 배경색을 바꿔 주었습니다. useBackgroundColor라는 훅을 만들어서 배경색 관련 판단의 역할을 맡겼는데, 엄청 좋은 방법은 아니라서 후에 개선이 필요합니다. 
- [2] 구글 애즈에서 띄워주는 iframe의 width는 디바이스의 width를 따라가는데, 그것의 부모에게 padding이 있어서 가로 길이가 넘쳤습니다. 따라서 부모의 padding을 0으로 바꾸었습니다. 

