### PR TITLE
🚑hotfix: 키워드 X버튼 색상 변경

### DIFF
--- a/src/presentation/components/common/Keyword/Item/index.tsx
+++ b/src/presentation/components/common/Keyword/Item/index.tsx
@@ -1,7 +1,6 @@
 import { Keyword } from '@api/types/user';
-import { icCloseGrey, icCloseWhite } from '@assets/icons';
 import { COLOR } from '@styles/common/color';
-import { StKeywordItem, StCount, StMyDeleteBtn } from './style';
+import { StCount, StKeywordCloseBtn, StKeywordItem, StMyDeleteBtn } from './style';
 
 interface Props extends Keyword {
   isMutable: boolean;
@@ -28,9 +27,10 @@ function KeywordItem(props: Props) {
       <div>
         <div>{content}</div>
         {isMutable && !isMine && (
-          <img
+          <StKeywordCloseBtn
             onClick={onDeleteClick}
-            src={viewMode === 'linear' || color === COLOR.GRAY_2 ? icCloseGrey : icCloseWhite}
+            theme={viewMode === 'linear' || color === COLOR.GRAY_2 ? 'grey' : 'color'}
+            color={fontColor}
           />
         )}
       </div>

--- a/src/presentation/components/common/Keyword/Item/style.ts
+++ b/src/presentation/components/common/Keyword/Item/style.ts
@@ -1,5 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
+import { icCloseWhite } from '@assets/icons';
 import { COLOR } from '@styles/common/color';
 import { FONT_STYLES } from '@styles/common/font-style';
 
@@ -20,9 +21,22 @@ export const StKeywordItem = styled.div<{ color: string; fontColor: string }>`
     gap: 8px;
     ${FONT_STYLES.R_13_TITLE}
   }
-  img {
-    cursor: pointer;
-  }
+`;
+
+export const StKeywordCloseBtn = styled.div<{ color: string; theme: 'grey' | 'color' }>`
+  cursor: pointer;
+  mask-image: url(${icCloseWhite});
+  width: 13px;
+  height: 13px;
+  ${({ color, theme }) =>
+    theme === 'grey'
+      ? css`
+          background-color: ${COLOR.GRAY_6};
+        `
+      : css`
+          background-color: ${color};
+          opacity: 0.6;
+        `}
 `;
 
 export const StCount = styled.span`


### PR DESCRIPTION
## ⛓ Related Issues
- #434 

## 📋 작업 내용
- [x] 키워드 x버튼 색상을 글씨 색상으로 맞추었습니다

## 📌 PR Point
- 키워드 x버튼 색상을 글씨 색상으로 맞추었는데, 피그마 색상과 완전히 동일하지는 않고, 완전히 동일하려면 서버 api가 변경되어야 합니다 .. 그래서 추후에 수정이 필요합니다.

## 👀 스크린샷 / GIF / 링크
<img width="413" alt="image" src="https://user-images.githubusercontent.com/48249505/212560864-4edb8e5a-13ac-49f8-8abd-a4d5efb700f6.png">

